### PR TITLE
feat: adding namespace functionality

### DIFF
--- a/cmd/namespace.go
+++ b/cmd/namespace.go
@@ -1,0 +1,107 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/pierinho13/kubectl-peek/internal/kubernetes"
+	"github.com/pierinho13/kubectl-peek/internal/ui"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var namespaceCmd = &cobra.Command{
+	Use:     "namespace [pattern]",
+	Aliases: []string{"namespaces", "ns"},
+	Short:   "Select the namespace for a Kubernetes context",
+	Args:    cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		var pattern string
+
+		if len(args) == 1 {
+			pattern = args[0]
+		}
+
+		return runNamespace(
+			cmd.Context(),
+			cmd.OutOrStdout(),
+			pattern,
+		)
+	},
+}
+
+func runNamespace(
+	ctx context.Context,
+	out io.Writer,
+	pattern string,
+) error {
+	client, err := kubernetes.NewClient(
+		kubeconfig,
+		contextName,
+		"",
+	)
+	if err != nil {
+		return err
+	}
+
+	namespaceList, err := client.Clientset.
+		CoreV1().
+		Namespaces().
+		List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("list namespaces: %w", err)
+	}
+
+	namespaces := make([]string, 0, len(namespaceList.Items))
+	normalizedPattern := strings.ToLower(pattern)
+
+	for _, item := range namespaceList.Items {
+		if pattern == "" ||
+			strings.Contains(
+				strings.ToLower(item.Name),
+				normalizedPattern,
+			) {
+			namespaces = append(namespaces, item.Name)
+		}
+	}
+
+	if len(namespaces) == 0 {
+		if pattern != "" {
+			return fmt.Errorf(
+				"no namespaces matching %q found",
+				pattern,
+			)
+		}
+
+		return fmt.Errorf("no namespaces found")
+	}
+
+	sort.Strings(namespaces)
+
+	selectedNamespace, err := ui.SelectNamespace(namespaces)
+	if err != nil {
+		return err
+	}
+
+	changedContext, err := kubernetes.SetContextNamespace(
+		kubeconfig,
+		contextName,
+		selectedNamespace,
+	)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(
+		out,
+		"Context %q now uses namespace %q\n",
+		changedContext,
+		selectedNamespace,
+	)
+
+	return nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,7 +34,6 @@ var rootCmd = &cobra.Command{
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	Args:          cobra.MaximumNArgs(1),
-
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var pattern string
 
@@ -51,6 +50,12 @@ var rootCmd = &cobra.Command{
 }
 
 func init() {
+	// This registration is what makes Cobra route:
+	//   kubectl-peek namespace
+	//   kubectl-peek ns
+	// to namespaceCmd instead of treating "namespace" as a Secret pattern.
+	rootCmd.AddCommand(namespaceCmd)
+
 	rootCmd.Flags().StringVarP(
 		&namespace,
 		"namespace",
@@ -59,14 +64,14 @@ func init() {
 		"Kubernetes namespace",
 	)
 
-	rootCmd.Flags().StringVar(
+	rootCmd.PersistentFlags().StringVar(
 		&contextName,
 		"context",
 		"",
 		"Kubernetes context",
 	)
 
-	rootCmd.Flags().StringVar(
+	rootCmd.PersistentFlags().StringVar(
 		&kubeconfig,
 		"kubeconfig",
 		"",

--- a/internal/kubernetes/context_namespace.go
+++ b/internal/kubernetes/context_namespace.go
@@ -1,0 +1,65 @@
+package kubernetes
+
+import (
+	"fmt"
+
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+func SetContextNamespace(
+	kubeconfig string,
+	contextName string,
+	namespace string,
+) (string, error) {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+
+	if kubeconfig != "" {
+		loadingRules.ExplicitPath = kubeconfig
+	}
+
+	config, err := loadingRules.Load()
+	if err != nil {
+		return "", fmt.Errorf(
+			"load Kubernetes configuration: %w",
+			err,
+		)
+	}
+
+	targetContext := contextName
+	if targetContext == "" {
+		targetContext = config.CurrentContext
+	}
+
+	if targetContext == "" {
+		return "", fmt.Errorf(
+			"Kubernetes configuration has no current context",
+		)
+	}
+
+	currentContext, ok := config.Contexts[targetContext]
+	if !ok || currentContext == nil {
+		return "", fmt.Errorf(
+			"Kubernetes context %q not found",
+			targetContext,
+		)
+	}
+
+	updatedContext := currentContext.DeepCopy()
+	updatedContext.Namespace = namespace
+	config.Contexts[targetContext] = updatedContext
+
+	if err := clientcmd.ModifyConfig(
+		loadingRules,
+		*config,
+		false,
+	); err != nil {
+		return "", fmt.Errorf(
+			"set namespace %q for context %q: %w",
+			namespace,
+			targetContext,
+			err,
+		)
+	}
+
+	return targetContext, nil
+}

--- a/internal/kubernetes/context_namespace_test.go
+++ b/internal/kubernetes/context_namespace_test.go
@@ -1,0 +1,65 @@
+package kubernetes
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+func TestSetContextNamespaceUpdatesCurrentContext(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	kubeconfig := filepath.Join(t.TempDir(), "config")
+
+	config := api.NewConfig()
+	config.CurrentContext = "development"
+	config.Contexts["development"] = &api.Context{
+		Cluster:   "cluster",
+		AuthInfo:  "user",
+		Namespace: "default",
+	}
+
+	data, err := clientcmd.Write(*config)
+	if err != nil {
+		t.Fatalf("write kubeconfig: %v", err)
+	}
+
+	if err := os.WriteFile(kubeconfig, data, 0o600); err != nil {
+		t.Fatalf("write kubeconfig file: %v", err)
+	}
+
+	contextName, err := SetContextNamespace(
+		kubeconfig,
+		"",
+		"monitoring",
+	)
+	if err != nil {
+		t.Fatalf("SetContextNamespace() error = %v", err)
+	}
+
+	if contextName != "development" {
+		t.Fatalf(
+			"expected context development, got %q",
+			contextName,
+		)
+	}
+
+	updated, err := clientcmd.LoadFromFile(kubeconfig)
+	if err != nil {
+		t.Fatalf("load updated kubeconfig: %v", err)
+	}
+
+	got := updated.Contexts["development"].Namespace
+
+	if got != "monitoring" {
+		t.Fatalf(
+			"expected namespace monitoring, got %q",
+			got,
+		)
+	}
+}

--- a/internal/ui/namespace_selector.go
+++ b/internal/ui/namespace_selector.go
@@ -1,0 +1,393 @@
+package ui
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"unicode"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+type namespaceSelectorModel struct {
+	allNamespaces      []string
+	filteredNamespaces []string
+
+	filter    []rune
+	filtering bool
+
+	cursor   int
+	page     int
+	pageSize int
+
+	selected  string
+	cancelled bool
+
+	windowHeight int
+}
+
+func newNamespaceSelectorModel(
+	namespaceNames []string,
+) namespaceSelectorModel {
+	names := append([]string(nil), namespaceNames...)
+	sort.Strings(names)
+
+	return namespaceSelectorModel{
+		allNamespaces:      names,
+		filteredNamespaces: names,
+		pageSize:           defaultPageSize,
+	}
+}
+
+func (m namespaceSelectorModel) Init() tea.Cmd {
+	return nil
+}
+
+func (m namespaceSelectorModel) Update(
+	msg tea.Msg,
+) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.windowHeight = msg.Height
+		return m, nil
+
+	case tea.KeyPressMsg:
+		keyName := msg.String()
+
+		if m.filtering {
+			return m.updateFiltering(msg, keyName)
+		}
+
+		switch keyName {
+		case "ctrl+c", "esc", "q":
+			m.cancelled = true
+			return m, tea.Quit
+
+		case "/":
+			m.filtering = true
+			return m, nil
+
+		case "up", "k":
+			m.moveUp()
+			return m, nil
+
+		case "down", "j":
+			m.moveDown()
+			return m, nil
+
+		case "left":
+			m.previousPage()
+			return m, nil
+
+		case "right":
+			m.nextPage()
+			return m, nil
+
+		case "enter":
+			if len(m.filteredNamespaces) == 0 {
+				return m, nil
+			}
+
+			m.selected = m.filteredNamespaces[m.cursor]
+			return m, tea.Quit
+		}
+	}
+
+	return m, nil
+}
+
+func (m namespaceSelectorModel) updateFiltering(
+	msg tea.KeyPressMsg,
+	keyName string,
+) (tea.Model, tea.Cmd) {
+	switch keyName {
+	case "ctrl+c":
+		m.cancelled = true
+		return m, tea.Quit
+
+	case "esc":
+		m.filtering = false
+		return m, nil
+
+	case "enter":
+		if len(m.filteredNamespaces) == 0 {
+			return m, nil
+		}
+
+		m.selected = m.filteredNamespaces[m.cursor]
+		return m, tea.Quit
+
+	case "backspace":
+		if len(m.filter) > 0 {
+			m.filter = m.filter[:len(m.filter)-1]
+			m.applyFilter()
+		}
+
+		return m, nil
+
+	case "up":
+		m.moveUp()
+		return m, nil
+
+	case "down":
+		m.moveDown()
+		return m, nil
+	}
+
+	if msg.Text == "" {
+		return m, nil
+	}
+
+	for _, character := range msg.Text {
+		if unicode.IsPrint(character) {
+			m.filter = append(m.filter, character)
+		}
+	}
+
+	m.applyFilter()
+	return m, nil
+}
+
+func (m *namespaceSelectorModel) applyFilter() {
+	query := strings.ToLower(
+		strings.TrimSpace(string(m.filter)),
+	)
+
+	if query == "" {
+		m.filteredNamespaces = m.allNamespaces
+	} else {
+		m.filteredNamespaces = make([]string, 0)
+
+		for _, name := range m.allNamespaces {
+			if strings.Contains(strings.ToLower(name), query) {
+				m.filteredNamespaces = append(
+					m.filteredNamespaces,
+					name,
+				)
+			}
+		}
+	}
+
+	m.cursor = 0
+	m.page = 0
+}
+
+func (m *namespaceSelectorModel) moveUp() {
+	if len(m.filteredNamespaces) == 0 {
+		return
+	}
+
+	if m.cursor > 0 {
+		m.cursor--
+	}
+
+	if !m.hasFilter() {
+		m.page = m.cursor / m.pageSize
+	}
+}
+
+func (m *namespaceSelectorModel) moveDown() {
+	if len(m.filteredNamespaces) == 0 {
+		return
+	}
+
+	if m.cursor < len(m.filteredNamespaces)-1 {
+		m.cursor++
+	}
+
+	if !m.hasFilter() {
+		m.page = m.cursor / m.pageSize
+	}
+}
+
+func (m *namespaceSelectorModel) previousPage() {
+	if m.hasFilter() || m.page == 0 {
+		return
+	}
+
+	m.page--
+	m.cursor = m.page * m.pageSize
+}
+
+func (m *namespaceSelectorModel) nextPage() {
+	if m.hasFilter() || m.page >= m.totalPages()-1 {
+		return
+	}
+
+	m.page++
+
+	nextCursor := m.page * m.pageSize
+	if nextCursor < len(m.filteredNamespaces) {
+		m.cursor = nextCursor
+	}
+}
+
+func (m namespaceSelectorModel) hasFilter() bool {
+	return strings.TrimSpace(string(m.filter)) != ""
+}
+
+func (m namespaceSelectorModel) totalPages() int {
+	if len(m.filteredNamespaces) == 0 {
+		return 1
+	}
+
+	return (len(m.filteredNamespaces) + m.pageSize - 1) /
+		m.pageSize
+}
+
+func (m namespaceSelectorModel) visibleNamespaces() (
+	[]string,
+	int,
+) {
+	if len(m.filteredNamespaces) == 0 {
+		return nil, 0
+	}
+
+	if !m.hasFilter() {
+		start := m.page * m.pageSize
+		end := start + m.pageSize
+
+		if end > len(m.filteredNamespaces) {
+			end = len(m.filteredNamespaces)
+		}
+
+		return m.filteredNamespaces[start:end], start
+	}
+
+	maxVisible := m.windowHeight - 7
+	if maxVisible < 5 {
+		maxVisible = 5
+	}
+	if maxVisible > len(m.filteredNamespaces) {
+		maxVisible = len(m.filteredNamespaces)
+	}
+
+	start := m.cursor - maxVisible/2
+	if start < 0 {
+		start = 0
+	}
+
+	maxStart := len(m.filteredNamespaces) - maxVisible
+	if start > maxStart {
+		start = maxStart
+	}
+
+	return m.filteredNamespaces[start : start+maxVisible], start
+}
+
+func (m namespaceSelectorModel) View() tea.View {
+	var builder strings.Builder
+
+	builder.WriteString(
+		titleStyle.Render("Select a namespace"),
+	)
+	builder.WriteString("\n")
+
+	if m.filtering || m.hasFilter() {
+		builder.WriteString(
+			filterStyle.Render(
+				fmt.Sprintf("/%s", string(m.filter)),
+			),
+		)
+		builder.WriteString("\n")
+	}
+
+	builder.WriteString(
+		descriptionStyle.Render(
+			"Use ↑/↓ to move, ←/→ to change page, and / to filter.",
+		),
+	)
+	builder.WriteString("\n\n")
+
+	visibleNamespaces, offset := m.visibleNamespaces()
+
+	if len(visibleNamespaces) == 0 {
+		builder.WriteString(
+			emptyStyle.Render("  No matching namespaces"),
+		)
+		builder.WriteString("\n")
+	} else {
+		for index, name := range visibleNamespaces {
+			absoluteIndex := offset + index
+			selected := absoluteIndex == m.cursor
+
+			builder.WriteString(
+				renderNamespaceLine(name, selected),
+			)
+			builder.WriteString("\n")
+		}
+	}
+
+	builder.WriteString("\n")
+	builder.WriteString(footerStyle.Render(m.footer()))
+
+	return tea.NewView(builder.String())
+}
+
+func (m namespaceSelectorModel) footer() string {
+	if m.hasFilter() {
+		if len(m.filteredNamespaces) == 0 {
+			return "0 matching namespaces"
+		}
+
+		return fmt.Sprintf(
+			"%d matching namespaces · %d/%d selected",
+			len(m.filteredNamespaces),
+			m.cursor+1,
+			len(m.filteredNamespaces),
+		)
+	}
+
+	return fmt.Sprintf(
+		"Page %d/%d · %d namespaces",
+		m.page+1,
+		m.totalPages(),
+		len(m.filteredNamespaces),
+	)
+}
+
+func renderNamespaceLine(
+	name string,
+	selected bool,
+) string {
+	if selected {
+		return selectedStyle.Render("> " + name)
+	}
+
+	return normalStyle.Render("  " + name)
+}
+
+func SelectNamespace(
+	namespaceNames []string,
+) (string, error) {
+	if len(namespaceNames) == 0 {
+		return "", fmt.Errorf("no namespaces found")
+	}
+
+	finalModel, err := tea.NewProgram(
+		newNamespaceSelectorModel(namespaceNames),
+	).Run()
+	if err != nil {
+		return "", fmt.Errorf(
+			"run namespace selector: %w",
+			err,
+		)
+	}
+
+	result, ok := finalModel.(namespaceSelectorModel)
+	if !ok {
+		return "", fmt.Errorf(
+			"unexpected namespace selector model",
+		)
+	}
+
+	if result.cancelled {
+		return "", fmt.Errorf("selection cancelled")
+	}
+
+	if result.selected == "" {
+		return "", fmt.Errorf("no namespace selected")
+	}
+
+	return result.selected, nil
+}

--- a/internal/ui/namespace_selector_test.go
+++ b/internal/ui/namespace_selector_test.go
@@ -1,0 +1,72 @@
+package ui
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNamespaceSelectorSortsNamespaces(t *testing.T) {
+	t.Parallel()
+
+	model := newNamespaceSelectorModel(
+		[]string{"monitoring", "default", "kube-system"},
+	)
+
+	want := []string{"default", "kube-system", "monitoring"}
+
+	if !reflect.DeepEqual(model.allNamespaces, want) {
+		t.Fatalf(
+			"expected sorted namespaces %v, got %v",
+			want,
+			model.allNamespaces,
+		)
+	}
+}
+
+func TestNamespaceSelectorFiltersCaseInsensitively(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	model := newNamespaceSelectorModel(
+		[]string{
+			"monitoring",
+			"devbox-sre-3",
+			"devbox-platform",
+		},
+	)
+
+	model.filter = []rune("DEVBOX")
+	model.applyFilter()
+
+	want := []string{
+		"devbox-platform",
+		"devbox-sre-3",
+	}
+
+	if !reflect.DeepEqual(model.filteredNamespaces, want) {
+		t.Fatalf(
+			"expected namespaces %v, got %v",
+			want,
+			model.filteredNamespaces,
+		)
+	}
+}
+
+func TestNamespaceSelectorPagination(t *testing.T) {
+	t.Parallel()
+
+	model := newNamespaceSelectorModel(
+		[]string{"ns-01", "ns-02", "ns-03"},
+	)
+	model.pageSize = 2
+	model.nextPage()
+
+	if model.page != 1 {
+		t.Fatalf("expected page 1, got %d", model.page)
+	}
+
+	if model.cursor != 2 {
+		t.Fatalf("expected cursor 2, got %d", model.cursor)
+	}
+}

--- a/readme.md
+++ b/readme.md
@@ -585,7 +585,7 @@ uses `./temporary-rules.yaml` for that execution.
 
 ```text
 Secret: garage-admin-token
-Namespace: devbox-sre-3
+Namespace: sandbox-3
 Type: Opaque
 Used by:
   ExternalSecret/garage-admin-token
@@ -828,7 +828,7 @@ After selecting a namespace, `kubectl-peek` updates the default namespace of the
 You can also provide an initial namespace filter:
 
 ```bash
-kubectl-peek namespace devbox
+kubectl-peek namespace sandbox
 ```
 
 The equivalent native plugin commands are:

--- a/readme.md
+++ b/readme.md
@@ -805,6 +805,40 @@ Test the `kubectl` plugin form by placing the binary in your `PATH`:
 kubectl peek
 ```
 
+## Additional functionality
+
+Although Secret inspection is the main focus of `kubectl-peek`, the tool also includes a small namespace helper.
+
+Run:
+
+```bash
+kubectl-peek namespace
+```
+
+or use the shorter alias:
+
+```bash
+kubectl-peek ns
+```
+
+This opens an interactive, paginated namespace selector with the same keyboard navigation and filtering behavior used by the Secret selector.
+
+After selecting a namespace, `kubectl-peek` updates the default namespace of the active kubeconfig context and prints the context that was changed.
+
+You can also provide an initial namespace filter:
+
+```bash
+kubectl-peek namespace devbox
+```
+
+The equivalent native plugin commands are:
+
+```bash
+kubectl peek namespace
+kubectl peek ns
+```
+
+This functionality is provided as a convenience and does not change the primary purpose of `kubectl-peek`, which is inspecting Kubernetes Secrets and their relationships.
 
 ## Roadmap
 


### PR DESCRIPTION
## Summary

Add an interactive namespace selector to `kubectl-peek`.


## Changes

* Add `kubectl-peek namespace`
* Add aliases:

  * `kubectl-peek ns`
  * `kubectl-peek namespaces`
* List namespaces using the current kubeconfig and context
* Add paginated namespace selection
* Add interactive filtering with `/`
* Support an initial namespace filter:

```bash
kubectl-peek namespace devbox
```

* Persist the selected namespace in the target kubeconfig context
* Support `--context` and `--kubeconfig`
* Print the updated context and namespace after selection
* Document the new functionality in the README

## Examples

```bash
kubectl-peek namespace
kubectl-peek ns
kubectl-peek namespace sandbox-1
kubectl-peek namespace --context staging
kubectl peek namespace
```
