### PR TITLE
feat: Add interactive context-aware isolated shells

### DIFF
--- a/cmd/namespace.go
+++ b/cmd/namespace.go
@@ -52,6 +52,12 @@ func runNamespace(
 	pattern string,
 	openShell bool,
 ) error {
+	if openShell {
+		if err := kubernetes.EnsureNoActiveNamespaceShell(); err != nil {
+			return err
+		}
+	}
+
 	client, err := kubernetes.NewClient(
 		kubeconfig,
 		contextName,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,7 +54,10 @@ func init() {
 	//   kubectl-peek namespace
 	//   kubectl-peek ns
 	// to namespaceCmd instead of treating "namespace" as a Secret pattern.
-	rootCmd.AddCommand(namespaceCmd)
+	rootCmd.AddCommand(
+		namespaceCmd,
+		shellCmd,
+	)
 
 	rootCmd.Flags().StringVarP(
 		&namespace,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -50,10 +50,6 @@ var rootCmd = &cobra.Command{
 }
 
 func init() {
-	// This registration is what makes Cobra route:
-	//   kubectl-peek namespace
-	//   kubectl-peek ns
-	// to namespaceCmd instead of treating "namespace" as a Secret pattern.
 	rootCmd.AddCommand(
 		namespaceCmd,
 		shellCmd,

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -1,0 +1,131 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sort"
+
+	"github.com/pierinho13/kubectl-peek/internal/kubernetes"
+	"github.com/pierinho13/kubectl-peek/internal/ui"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var shellNamespace string
+
+var shellCmd = &cobra.Command{
+	Use:   "shell",
+	Short: "Open an isolated shell for a Kubernetes context and namespace",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runShell(
+			cmd.Context(),
+			cmd.OutOrStdout(),
+		)
+	},
+}
+
+func init() {
+	shellCmd.Flags().StringVarP(
+		&shellNamespace,
+		"namespace",
+		"n",
+		"",
+		"Kubernetes namespace",
+	)
+}
+
+func runShell(
+	ctx context.Context,
+	out io.Writer,
+) error {
+
+	if err := kubernetes.EnsureNoActiveNamespaceShell(); err != nil {
+		return err
+	}
+
+	selectedContext := contextName
+
+	if selectedContext == "" {
+		contextNames, err := kubernetes.ContextNames(kubeconfig)
+		if err != nil {
+			return err
+		}
+
+		selectedContext, err = ui.SelectContext(contextNames)
+		if err != nil {
+			return err
+		}
+	}
+
+	client, err := kubernetes.NewClient(
+		kubeconfig,
+		selectedContext,
+		"",
+	)
+	if err != nil {
+		return err
+	}
+
+	selectedNamespace := shellNamespace
+
+	if selectedNamespace != "" {
+		_, err := client.Clientset.
+			CoreV1().
+			Namespaces().
+			Get(
+				ctx,
+				selectedNamespace,
+				metav1.GetOptions{},
+			)
+		if err != nil {
+			return fmt.Errorf(
+				"get namespace %q from context %q: %w",
+				selectedNamespace,
+				selectedContext,
+				err,
+			)
+		}
+	} else {
+		namespaceList, err := client.Clientset.
+			CoreV1().
+			Namespaces().
+			List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return fmt.Errorf(
+				"list namespaces from context %q: %w",
+				selectedContext,
+				err,
+			)
+		}
+
+		namespaces := make(
+			[]string,
+			0,
+			len(namespaceList.Items),
+		)
+
+		for _, item := range namespaceList.Items {
+			namespaces = append(
+				namespaces,
+				item.Name,
+			)
+		}
+
+		sort.Strings(namespaces)
+
+		selectedNamespace, err = ui.SelectNamespace(namespaces)
+		if err != nil {
+			return err
+		}
+	}
+
+	return kubernetes.RunNamespaceShell(
+		kubeconfig,
+		selectedContext,
+		selectedNamespace,
+		out,
+	)
+}

--- a/internal/kubernetes/contexts.go
+++ b/internal/kubernetes/contexts.go
@@ -1,0 +1,44 @@
+package kubernetes
+
+import (
+	"fmt"
+	"sort"
+)
+
+func ContextNames(
+	kubeconfig string,
+) ([]string, error) {
+	loadingRules := newLoadingRules(kubeconfig)
+
+	config, err := loadingRules.Load()
+	if err != nil {
+		return nil, fmt.Errorf(
+			"load Kubernetes configuration: %w",
+			err,
+		)
+	}
+
+	contextNames := make(
+		[]string,
+		0,
+		len(config.Contexts),
+	)
+
+	for name, context := range config.Contexts {
+		if context == nil {
+			continue
+		}
+
+		contextNames = append(contextNames, name)
+	}
+
+	if len(contextNames) == 0 {
+		return nil, fmt.Errorf(
+			"Kubernetes configuration contains no contexts",
+		)
+	}
+
+	sort.Strings(contextNames)
+
+	return contextNames, nil
+}

--- a/internal/kubernetes/contexts_test.go
+++ b/internal/kubernetes/contexts_test.go
@@ -1,0 +1,44 @@
+package kubernetes
+
+import (
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+func TestContextNames(t *testing.T) {
+	t.Parallel()
+
+	config := clientcmdapi.NewConfig()
+	config.Contexts["staging"] = &clientcmdapi.Context{}
+	config.Contexts["operations"] = &clientcmdapi.Context{}
+	config.Contexts["production"] = &clientcmdapi.Context{}
+
+	path := filepath.Join(t.TempDir(), "config")
+
+	if err := clientcmd.WriteToFile(*config, path); err != nil {
+		t.Fatalf("write kubeconfig: %v", err)
+	}
+
+	got, err := ContextNames(path)
+	if err != nil {
+		t.Fatalf("ContextNames() error = %v", err)
+	}
+
+	want := []string{
+		"operations",
+		"production",
+		"staging",
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf(
+			"ContextNames() = %v, want %v",
+			got,
+			want,
+		)
+	}
+}

--- a/internal/kubernetes/namespace_shell.go
+++ b/internal/kubernetes/namespace_shell.go
@@ -468,3 +468,26 @@ func shellQuote(value string) string {
 		`'\''`,
 	) + "'"
 }
+
+func EnsureNoActiveNamespaceShell() error {
+	if os.Getenv(namespaceShellEnvironment) == "" {
+		return nil
+	}
+
+	currentContext := os.Getenv("KUBECTL_PEEK_CONTEXT")
+	currentNamespace := os.Getenv("KUBECTL_PEEK_NAMESPACE")
+
+	if currentContext != "" && currentNamespace != "" {
+		return fmt.Errorf(
+			"an isolated kubectl-peek shell is already active "+
+				"(context %q, namespace %q); run exit before opening another one",
+			currentContext,
+			currentNamespace,
+		)
+	}
+
+	return fmt.Errorf(
+		"an isolated kubectl-peek shell is already active; " +
+			"run exit before opening another one",
+	)
+}

--- a/internal/kubernetes/secret_usage_test.go
+++ b/internal/kubernetes/secret_usage_test.go
@@ -262,7 +262,6 @@ func TestFindSecretUsages(t *testing.T) {
 			},
 		},
 
-		// Este recurso referencia otro Secret y no debe aparecer.
 		&appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "unrelated",

--- a/internal/kubernetes/usage/rules.go
+++ b/internal/kubernetes/usage/rules.go
@@ -315,7 +315,6 @@ func findObjectRuleReferences(
 			rule.Path,
 		)
 		if err != nil {
-			// La ruta ya fue validada antes de procesar los objetos.
 			continue
 		}
 

--- a/internal/ui/context_selector.go
+++ b/internal/ui/context_selector.go
@@ -1,0 +1,395 @@
+package ui
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"unicode"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+type contextSelectorModel struct {
+	allContexts      []string
+	filteredContexts []string
+
+	filter    []rune
+	filtering bool
+
+	cursor   int
+	page     int
+	pageSize int
+
+	selected  string
+	cancelled bool
+
+	windowHeight int
+}
+
+func newContextSelectorModel(
+	contextNames []string,
+) contextSelectorModel {
+	names := append([]string(nil), contextNames...)
+	sort.Strings(names)
+
+	return contextSelectorModel{
+		allContexts:      names,
+		filteredContexts: names,
+		pageSize:         defaultPageSize,
+	}
+}
+
+func (m contextSelectorModel) Init() tea.Cmd {
+	return nil
+}
+
+func (m contextSelectorModel) Update(
+	msg tea.Msg,
+) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.windowHeight = msg.Height
+		return m, nil
+
+	case tea.KeyPressMsg:
+		keyName := msg.String()
+
+		if m.filtering {
+			return m.updateFiltering(msg, keyName)
+		}
+
+		switch keyName {
+		case "ctrl+c", "esc", "q":
+			m.cancelled = true
+			return m, tea.Quit
+
+		case "/":
+			m.filtering = true
+			return m, nil
+
+		case "up", "k":
+			m.moveUp()
+			return m, nil
+
+		case "down", "j":
+			m.moveDown()
+			return m, nil
+
+		case "left":
+			m.previousPage()
+			return m, nil
+
+		case "right":
+			m.nextPage()
+			return m, nil
+
+		case "enter":
+			if len(m.filteredContexts) == 0 {
+				return m, nil
+			}
+
+			m.selected = m.filteredContexts[m.cursor]
+			return m, tea.Quit
+		}
+	}
+
+	return m, nil
+}
+
+func (m contextSelectorModel) updateFiltering(
+	msg tea.KeyPressMsg,
+	keyName string,
+) (tea.Model, tea.Cmd) {
+	switch keyName {
+	case "ctrl+c":
+		m.cancelled = true
+		return m, tea.Quit
+
+	case "esc":
+		m.filtering = false
+		return m, nil
+
+	case "enter":
+		if len(m.filteredContexts) == 0 {
+			return m, nil
+		}
+
+		m.selected = m.filteredContexts[m.cursor]
+		return m, tea.Quit
+
+	case "backspace":
+		if len(m.filter) > 0 {
+			m.filter = m.filter[:len(m.filter)-1]
+			m.applyFilter()
+		}
+
+		return m, nil
+
+	case "up":
+		m.moveUp()
+		return m, nil
+
+	case "down":
+		m.moveDown()
+		return m, nil
+	}
+
+	if msg.Text == "" {
+		return m, nil
+	}
+
+	for _, character := range msg.Text {
+		if unicode.IsPrint(character) {
+			m.filter = append(m.filter, character)
+		}
+	}
+
+	m.applyFilter()
+
+	return m, nil
+}
+
+func (m *contextSelectorModel) applyFilter() {
+	query := strings.ToLower(
+		strings.TrimSpace(string(m.filter)),
+	)
+
+	if query == "" {
+		m.filteredContexts = m.allContexts
+	} else {
+		m.filteredContexts = make([]string, 0)
+
+		for _, name := range m.allContexts {
+			if strings.Contains(strings.ToLower(name), query) {
+				m.filteredContexts = append(
+					m.filteredContexts,
+					name,
+				)
+			}
+		}
+	}
+
+	m.cursor = 0
+	m.page = 0
+}
+
+func (m *contextSelectorModel) moveUp() {
+	if len(m.filteredContexts) == 0 {
+		return
+	}
+
+	if m.cursor > 0 {
+		m.cursor--
+	}
+
+	if !m.hasFilter() {
+		m.page = m.cursor / m.pageSize
+	}
+}
+
+func (m *contextSelectorModel) moveDown() {
+	if len(m.filteredContexts) == 0 {
+		return
+	}
+
+	if m.cursor < len(m.filteredContexts)-1 {
+		m.cursor++
+	}
+
+	if !m.hasFilter() {
+		m.page = m.cursor / m.pageSize
+	}
+}
+
+func (m *contextSelectorModel) previousPage() {
+	if m.hasFilter() || m.page == 0 {
+		return
+	}
+
+	m.page--
+	m.cursor = m.page * m.pageSize
+}
+
+func (m *contextSelectorModel) nextPage() {
+	if m.hasFilter() || m.page >= m.totalPages()-1 {
+		return
+	}
+
+	m.page++
+
+	nextCursor := m.page * m.pageSize
+	if nextCursor < len(m.filteredContexts) {
+		m.cursor = nextCursor
+	}
+}
+
+func (m contextSelectorModel) hasFilter() bool {
+	return strings.TrimSpace(string(m.filter)) != ""
+}
+
+func (m contextSelectorModel) totalPages() int {
+	if len(m.filteredContexts) == 0 {
+		return 1
+	}
+
+	return (len(m.filteredContexts) + m.pageSize - 1) /
+		m.pageSize
+}
+
+func (m contextSelectorModel) visibleContexts() (
+	[]string,
+	int,
+) {
+	if len(m.filteredContexts) == 0 {
+		return nil, 0
+	}
+
+	if !m.hasFilter() {
+		start := m.page * m.pageSize
+		end := start + m.pageSize
+
+		if end > len(m.filteredContexts) {
+			end = len(m.filteredContexts)
+		}
+
+		return m.filteredContexts[start:end], start
+	}
+
+	maxVisible := m.windowHeight - 7
+	if maxVisible < 5 {
+		maxVisible = 5
+	}
+
+	if maxVisible > len(m.filteredContexts) {
+		maxVisible = len(m.filteredContexts)
+	}
+
+	start := m.cursor - maxVisible/2
+	if start < 0 {
+		start = 0
+	}
+
+	maxStart := len(m.filteredContexts) - maxVisible
+	if start > maxStart {
+		start = maxStart
+	}
+
+	return m.filteredContexts[start : start+maxVisible], start
+}
+
+func (m contextSelectorModel) View() tea.View {
+	var builder strings.Builder
+
+	builder.WriteString(
+		titleStyle.Render("Select a Kubernetes context"),
+	)
+	builder.WriteString("\n")
+
+	if m.filtering || m.hasFilter() {
+		builder.WriteString(
+			filterStyle.Render(
+				fmt.Sprintf("/%s", string(m.filter)),
+			),
+		)
+		builder.WriteString("\n")
+	}
+
+	builder.WriteString(
+		descriptionStyle.Render(
+			"Use ↑/↓ to move, ←/→ to change page, and / to filter.",
+		),
+	)
+	builder.WriteString("\n\n")
+
+	visibleContexts, offset := m.visibleContexts()
+
+	if len(visibleContexts) == 0 {
+		builder.WriteString(
+			emptyStyle.Render("  No matching contexts"),
+		)
+		builder.WriteString("\n")
+	} else {
+		for index, name := range visibleContexts {
+			absoluteIndex := offset + index
+			selected := absoluteIndex == m.cursor
+
+			builder.WriteString(
+				renderContextLine(name, selected),
+			)
+			builder.WriteString("\n")
+		}
+	}
+
+	builder.WriteString("\n")
+	builder.WriteString(footerStyle.Render(m.footer()))
+
+	return tea.NewView(builder.String())
+}
+
+func (m contextSelectorModel) footer() string {
+	if m.hasFilter() {
+		if len(m.filteredContexts) == 0 {
+			return "0 matching contexts"
+		}
+
+		return fmt.Sprintf(
+			"%d matching contexts · %d/%d selected",
+			len(m.filteredContexts),
+			m.cursor+1,
+			len(m.filteredContexts),
+		)
+	}
+
+	return fmt.Sprintf(
+		"Page %d/%d · %d contexts",
+		m.page+1,
+		m.totalPages(),
+		len(m.filteredContexts),
+	)
+}
+
+func renderContextLine(
+	name string,
+	selected bool,
+) string {
+	if selected {
+		return selectedStyle.Render("> " + name)
+	}
+
+	return normalStyle.Render("  " + name)
+}
+
+func SelectContext(
+	contextNames []string,
+) (string, error) {
+	if len(contextNames) == 0 {
+		return "", fmt.Errorf("no Kubernetes contexts found")
+	}
+
+	finalModel, err := tea.NewProgram(
+		newContextSelectorModel(contextNames),
+	).Run()
+	if err != nil {
+		return "", fmt.Errorf(
+			"run context selector: %w",
+			err,
+		)
+	}
+
+	result, ok := finalModel.(contextSelectorModel)
+	if !ok {
+		return "", fmt.Errorf(
+			"unexpected context selector model",
+		)
+	}
+
+	if result.cancelled {
+		return "", fmt.Errorf("selection cancelled")
+	}
+
+	if result.selected == "" {
+		return "", fmt.Errorf("no context selected")
+	}
+
+	return result.selected, nil
+}

--- a/internal/ui/context_selector_test.go
+++ b/internal/ui/context_selector_test.go
@@ -1,0 +1,58 @@
+package ui
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestContextSelectorSortsContexts(t *testing.T) {
+	t.Parallel()
+
+	model := newContextSelectorModel(
+		[]string{"staging", "operations", "production"},
+	)
+
+	want := []string{
+		"operations",
+		"production",
+		"staging",
+	}
+
+	if !reflect.DeepEqual(model.allContexts, want) {
+		t.Fatalf(
+			"expected sorted contexts %v, got %v",
+			want,
+			model.allContexts,
+		)
+	}
+}
+
+func TestContextSelectorFiltersCaseInsensitively(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	model := newContextSelectorModel(
+		[]string{
+			"operations-admin",
+			"operations-readonly",
+			"staging",
+		},
+	)
+
+	model.filter = []rune("OPERATIONS")
+	model.applyFilter()
+
+	want := []string{
+		"operations-admin",
+		"operations-readonly",
+	}
+
+	if !reflect.DeepEqual(model.filteredContexts, want) {
+		t.Fatalf(
+			"expected contexts %v, got %v",
+			want,
+			model.filteredContexts,
+		)
+	}
+}

--- a/internal/ui/namespace_selector_test.go
+++ b/internal/ui/namespace_selector_test.go
@@ -31,17 +31,17 @@ func TestNamespaceSelectorFiltersCaseInsensitively(
 	model := newNamespaceSelectorModel(
 		[]string{
 			"monitoring",
-			"devbox-sre-3",
-			"devbox-platform",
+			"sandbox-3",
+			"sandbox-platform",
 		},
 	)
 
-	model.filter = []rune("DEVBOX")
+	model.filter = []rune("SANDBOX")
 	model.applyFilter()
 
 	want := []string{
-		"devbox-platform",
-		"devbox-sre-3",
+		"sandbox-3",
+		"sandbox-platform",
 	}
 
 	if !reflect.DeepEqual(model.filteredNamespaces, want) {
@@ -59,6 +59,7 @@ func TestNamespaceSelectorPagination(t *testing.T) {
 	model := newNamespaceSelectorModel(
 		[]string{"ns-01", "ns-02", "ns-03"},
 	)
+
 	model.pageSize = 2
 	model.nextPage()
 

--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,8 @@ The tool runs entirely on the client side using your existing kubeconfig. It doe
 - Optional Secret-name filtering from the command line.
 - Namespace, context, and kubeconfig overrides.
 - Interactive namespace selection and persistent context updates.
-- Isolated namespace shells backed by temporary kubeconfigs.
+- Interactive context and namespace selection with `kubectl-peek shell`.
+- Isolated Kubernetes shells backed by temporary kubeconfigs.
 - Visible context and namespace indicators in temporary shell prompts.
 - Decoded Secret values displayed directly in the terminal.
 - Built-in Secret relationship discovery.
@@ -172,7 +173,19 @@ To interactively select a namespace:
 kubectl-peek namespace
 ```
 
-To open an isolated shell scoped to a selected namespace:
+To interactively select a Kubernetes context and namespace, then open an isolated shell:
+
+```bash
+kubectl-peek shell
+```
+
+The equivalent native plugin command is:
+
+```bash
+kubectl peek shell
+```
+
+The existing namespace-first workflow is also available:
 
 ```bash
 kubectl-peek namespace --shell
@@ -272,9 +285,9 @@ kubectl-peek database \
   --rules ./examples/rules-all.yaml
 ```
 
-## Namespace selection and isolated shells
+## Context and namespace selection and isolated shells
 
-Secret inspection is the main focus of `kubectl-peek`, but the tool also provides an interactive namespace workflow for quickly changing or isolating the namespace used by Kubernetes commands.
+Secret inspection is the main focus of `kubectl-peek`, but the tool also provides interactive context and namespace workflows for changing the active namespace or opening an isolated Kubernetes shell.
 
 ### Select and persist a namespace
 
@@ -332,6 +345,93 @@ The equivalent native plugin commands are:
 kubectl peek namespace
 kubectl peek ns
 ```
+
+### Open an isolated context-aware shell
+
+Use `kubectl-peek shell` to select a Kubernetes context and then a namespace from that context:
+
+```bash
+kubectl-peek shell
+```
+
+The native plugin form behaves identically:
+
+```bash
+kubectl peek shell
+```
+
+The interactive flow is:
+
+```text
+Select a Kubernetes context
+            │
+            ▼
+List namespaces available through that context
+            │
+            ▼
+Select a namespace
+            │
+            ▼
+Create a temporary kubeconfig and open an isolated shell
+```
+
+A Kubernetes context is selected instead of a cluster directly because a context identifies the cluster and the credentials used to access it. After the context is known, `kubectl-peek` connects through that context and lists its available namespaces.
+
+You can skip either selector by passing its value directly.
+
+Use a specific context and select only the namespace:
+
+```bash
+kubectl-peek shell --context operations
+```
+
+Select a context interactively and use a specific namespace:
+
+```bash
+kubectl-peek shell --namespace traefik
+```
+
+or with the short namespace flag:
+
+```bash
+kubectl-peek shell -n traefik
+```
+
+Open the shell without interactive selectors:
+
+```bash
+kubectl-peek shell \
+  --context operations \
+  --namespace traefik
+```
+
+A namespace supplied through `--namespace` is validated against the selected context before the shell starts.
+
+The command also supports a separate kubeconfig:
+
+```bash
+kubectl-peek shell \
+  --kubeconfig ~/.kube/secondary-config
+```
+
+The following forms are equivalent:
+
+```bash
+kubectl-peek shell
+kubectl peek shell
+```
+
+When no flags are supplied, the original kubeconfig and its current context are not modified. The selected context and namespace are applied only to the temporary kubeconfig used by the child shell.
+
+If an isolated shell is already active, another one is rejected immediately, before displaying the context or namespace selectors:
+
+```text
+an isolated kubectl-peek shell is already active
+(context "operations", namespace "traefik");
+run exit before opening another one
+```
+
+Run `exit` before opening a different isolated shell.
 
 ### Open an isolated namespace shell
 
@@ -405,7 +505,7 @@ The temporary directory is removed after leaving the shell normally:
 exit
 ```
 
-Nested `kubectl-peek` namespace shells are blocked to avoid accidentally creating multiple shell layers.
+Nested isolated shells are blocked to avoid accidentally creating multiple shell layers. The check happens before opening an interactive selector for both `kubectl-peek shell` and `kubectl-peek namespace --shell`.
 
 ## Interactive controls
 
@@ -923,9 +1023,9 @@ Possible reasons include:
 
 The discovery result should be treated as helpful dependency information, not as a guarantee that deleting a Secret is safe.
 
-### Verify the active namespace shell
+### Verify the active isolated shell
 
-Inside an isolated namespace shell, inspect the temporary configuration with:
+Inside an isolated shell opened with `kubectl-peek shell` or `kubectl-peek namespace --shell`, inspect the temporary configuration with:
 
 ```bash
 echo "$KUBECONFIG"
@@ -965,6 +1065,14 @@ Test custom rules:
 
 ```bash
 ./kubectl-peek --rules ./examples/rules-all.yaml
+```
+
+Test the isolated shell workflow:
+
+```bash
+./kubectl-peek shell
+./kubectl-peek shell --context operations
+./kubectl-peek shell --context operations --namespace traefik
 ```
 
 Test the `kubectl` plugin form by placing the binary in your `PATH`:


### PR DESCRIPTION


## Summary

This PR adds a new `kubectl-peek shell` command for opening isolated Kubernetes
shells scoped to a selected context and namespace.

The command supports both interactive selection and direct flags.

## Usage

Interactive context and namespace selection:

```bash
kubectl-peek shell
```

Use a specific context and select only the namespace:

```bash
kubectl-peek shell --context operations
```

Select a context and use a specific namespace:

```bash
kubectl-peek shell --namespace traefik
```

Open the shell directly:

```bash
kubectl-peek shell \
  --context operations \
  --namespace traefik
```

The existing namespace workflow remains available:

```bash
kubectl-peek namespace --shell
```

## Behavior

The shell command:

1. Selects or validates the Kubernetes context.
2. Lists or validates namespaces from that context.
3. Creates a temporary flattened kubeconfig.
4. Updates only the selected context namespace.
5. Opens an isolated shell with context and namespace information in the prompt.
6. Removes the temporary files when the shell exits.

The user's original kubeconfig is not modified.

## Nested shell protection

Opening another isolated shell from inside an active one is rejected immediately,
before displaying the context or namespace selectors.

Example:

```text
an isolated kubectl-peek shell is already active
(context "demo-cluster", namespace "cnrm-system");
run exit before opening another one
```

This behavior works with both plugin invocation styles:

```bash
kubectl-peek shell
kubectl peek shell
kubectl-peek namespace --shell
kubectl peek namespace --shell
```

## Changes

- Add the `shell` Cobra subcommand.
- Add interactive Kubernetes context selection.
- Reuse the existing namespace selector.
- Support `--context`, `--namespace`, and `--kubeconfig`.
- Validate explicitly supplied namespaces.
- Add early nested-shell validation.
- Add context selector and kubeconfig context tests.
- Preserve all existing Secret and namespace command behavior.

## Testing

```bash
go test ./...
go build -o kubectl-peek .
```

Manual tests:

```bash
./kubectl-peek shell
./kubectl-peek shell --context operations
./kubectl-peek shell --namespace traefik
./kubectl-peek shell --context operations --namespace traefik
./kubectl-peek namespace --shell
```