### PR TITLE
feat: Add interactive Kubernetes event browsing

### DIFF
--- a/cmd/events.go
+++ b/cmd/events.go
@@ -1,0 +1,258 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/pierinho13/kubectl-peek/internal/kubernetes"
+	"github.com/pierinho13/kubectl-peek/internal/ui"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	eventsNamespace     string
+	eventsAllNamespaces bool
+	eventsWarningsOnly  bool
+	eventsNonNormalOnly bool
+	eventsNoGroup       bool
+	eventsBrowseByKind  bool
+)
+
+var eventsCmd = &cobra.Command{
+	Use:     "events [pattern]",
+	Aliases: []string{"event", "ev"},
+	Short:   "Browse Kubernetes events ordered by last occurrence",
+	Args:    cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		var pattern string
+		if len(args) == 1 {
+			pattern = args[0]
+		}
+
+		return runEvents(
+			cmd.Context(),
+			cmd.OutOrStdout(),
+			pattern,
+		)
+	},
+}
+
+func init() {
+	eventsCmd.Flags().StringVarP(
+		&eventsNamespace,
+		"namespace",
+		"n",
+		"",
+		"Kubernetes namespace",
+	)
+
+	eventsCmd.Flags().BoolVarP(
+		&eventsAllNamespaces,
+		"all-namespaces",
+		"A",
+		false,
+		"Show events from all namespaces",
+	)
+
+	eventsCmd.Flags().BoolVar(
+		&eventsWarningsOnly,
+		"warnings",
+		false,
+		"Show only Warning events",
+	)
+
+	eventsCmd.Flags().BoolVar(
+		&eventsNonNormalOnly,
+		"non-normal",
+		false,
+		"Show events whose type is not Normal",
+	)
+
+	eventsCmd.Flags().BoolVar(
+		&eventsNoGroup,
+		"no-group",
+		false,
+		"Show individual events without grouping repeated occurrences",
+	)
+
+	eventsCmd.Flags().BoolVar(
+		&eventsBrowseByKind,
+		"browse-by-kind",
+		false,
+		"Browse events by resource kind and resource",
+	)
+
+	eventsCmd.Flags().BoolVar(
+		&eventsBrowseByKind,
+		"browse",
+		false,
+		"Browse events by resource kind and resource",
+	)
+}
+
+func runEvents(
+	ctx context.Context,
+	out io.Writer,
+	pattern string,
+) error {
+	if eventsAllNamespaces && eventsNamespace != "" {
+		return fmt.Errorf("--all-namespaces cannot be used with --namespace")
+	}
+
+	if eventsWarningsOnly && eventsNonNormalOnly {
+		return fmt.Errorf("--warnings cannot be used with --non-normal")
+	}
+
+	client, err := kubernetes.NewClient(
+		kubeconfig,
+		contextName,
+		eventsNamespace,
+	)
+	if err != nil {
+		return err
+	}
+
+	namespace := client.Namespace
+	selectorNamespace := namespace
+
+	if eventsAllNamespaces {
+		namespace = metav1.NamespaceAll
+		selectorNamespace = ""
+	}
+
+	eventList, err := client.Clientset.
+		CoreV1().
+		Events(namespace).
+		List(ctx, metav1.ListOptions{})
+	if err != nil {
+		if eventsAllNamespaces {
+			return fmt.Errorf("list Kubernetes events across all namespaces: %w", err)
+		}
+
+		return fmt.Errorf(
+			"list Kubernetes events in namespace %q: %w",
+			namespace,
+			err,
+		)
+	}
+
+	records := kubernetes.EventRecords(
+		eventList.Items,
+		!eventsNoGroup,
+	)
+
+	records = filterEventRecords(records, pattern)
+
+	if len(records) == 0 {
+		return fmt.Errorf("no Kubernetes events matched the selected filters")
+	}
+
+	if eventsBrowseByKind {
+		selectedKind, err := ui.SelectEventKind(records)
+		if err != nil {
+			return err
+		}
+
+		selectedResource, err := ui.SelectEventResource(
+			selectedKind,
+			records,
+			eventsAllNamespaces,
+		)
+		if err != nil {
+			return err
+		}
+
+		records = filterEventRecordsByResource(
+			records,
+			selectedKind,
+			selectedResource,
+		)
+	}
+
+	selected, err := ui.SelectEvent(
+		selectorNamespace,
+		records,
+		!eventsNoGroup,
+	)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, ui.RenderEventDetail(selected))
+
+	return nil
+}
+
+func filterEventRecords(
+	records []kubernetes.EventRecord,
+	pattern string,
+) []kubernetes.EventRecord {
+	filtered := make([]kubernetes.EventRecord, 0, len(records))
+	normalizedPattern := strings.ToLower(strings.TrimSpace(pattern))
+
+	for _, record := range records {
+		if eventsWarningsOnly && record.Type != "Warning" {
+			continue
+		}
+
+		if eventsNonNormalOnly && record.Type == "Normal" {
+			continue
+		}
+
+		if normalizedPattern != "" {
+			searchable := strings.ToLower(strings.Join(
+				[]string{
+					record.Namespace,
+					record.Type,
+					record.Reason,
+					record.Kind,
+					record.Name,
+					record.Message,
+					record.Source,
+				},
+				" ",
+			))
+
+			if !strings.Contains(searchable, normalizedPattern) {
+				continue
+			}
+		}
+
+		filtered = append(filtered, record)
+	}
+
+	return filtered
+}
+
+func filterEventRecordsByResource(
+	records []kubernetes.EventRecord,
+	kind string,
+	resource ui.EventResourceSelection,
+) []kubernetes.EventRecord {
+	filtered := make(
+		[]kubernetes.EventRecord,
+		0,
+		len(records),
+	)
+
+	for _, record := range records {
+		if record.Kind != kind ||
+			record.Name != resource.Name {
+			continue
+		}
+
+		if resource.Namespace != "" &&
+			record.Namespace != resource.Namespace {
+			continue
+		}
+
+		filtered = append(filtered, record)
+	}
+
+	return filtered
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,6 +27,7 @@ func init() {
 		namespaceCmd,
 		shellCmd,
 		execCmd,
+		eventsCmd,
 	)
 
 	rootCmd.PersistentFlags().StringVar(

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -31,6 +31,7 @@ func TestRootCommandDisplaysHelp(t *testing.T) {
 		"namespace",
 		"shell",
 		"exec",
+		"events",
 	}
 
 	for _, expected := range expectedParts {

--- a/internal/kubernetes/events.go
+++ b/internal/kubernetes/events.go
@@ -1,0 +1,169 @@
+package kubernetes
+
+import (
+	"sort"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+type EventRecord struct {
+	Namespace string
+	Type      string
+	Reason    string
+	Kind      string
+	Name      string
+	Message   string
+	Source    string
+	Count        int32
+	EventObjects int
+	FirstSeen    time.Time
+	LastSeen  time.Time
+}
+
+func EventRecords(
+	events []corev1.Event,
+	group bool,
+) []EventRecord {
+	if !group {
+		records := make([]EventRecord, 0, len(events))
+
+		for i := range events {
+			records = append(records, eventRecord(&events[i]))
+		}
+
+		sortEventRecords(records)
+		return records
+	}
+
+	grouped := make(map[string]EventRecord)
+
+	for i := range events {
+		record := eventRecord(&events[i])
+		key := eventGroupKey(record)
+
+		existing, found := grouped[key]
+		if !found {
+			grouped[key] = record
+			continue
+		}
+
+		existing.Count += record.Count
+		existing.EventObjects += record.EventObjects
+
+		if existing.FirstSeen.IsZero() ||
+			(!record.FirstSeen.IsZero() && record.FirstSeen.Before(existing.FirstSeen)) {
+			existing.FirstSeen = record.FirstSeen
+		}
+
+		if record.LastSeen.After(existing.LastSeen) {
+			existing.LastSeen = record.LastSeen
+		}
+
+		if existing.Source == "" {
+			existing.Source = record.Source
+		}
+
+		grouped[key] = existing
+	}
+
+	records := make([]EventRecord, 0, len(grouped))
+
+	for _, record := range grouped {
+		records = append(records, record)
+	}
+
+	sortEventRecords(records)
+	return records
+}
+
+func eventRecord(event *corev1.Event) EventRecord {
+	count := event.Count
+	if event.Series != nil && event.Series.Count > count {
+		count = event.Series.Count
+	}
+	if count < 1 {
+		count = 1
+	}
+
+	firstSeen := event.FirstTimestamp.Time
+	if firstSeen.IsZero() {
+		firstSeen = event.CreationTimestamp.Time
+	}
+
+	lastSeen := eventLastSeen(event)
+	if lastSeen.IsZero() {
+		lastSeen = firstSeen
+	}
+
+	source := event.Source.Component
+	if event.Source.Host != "" {
+		if source != "" {
+			source += "/"
+		}
+		source += event.Source.Host
+	}
+
+	return EventRecord{
+		Namespace: event.Namespace,
+		Type:      event.Type,
+		Reason:    event.Reason,
+		Kind:      event.InvolvedObject.Kind,
+		Name:      event.InvolvedObject.Name,
+		Message:   event.Message,
+		Source:    source,
+		Count:        count,
+		EventObjects: 1,
+		FirstSeen:    firstSeen,
+		LastSeen:  lastSeen,
+	}
+}
+
+func eventLastSeen(event *corev1.Event) time.Time {
+	if event.Series != nil && !event.Series.LastObservedTime.IsZero() {
+		return event.Series.LastObservedTime.Time
+	}
+
+	if !event.EventTime.IsZero() {
+		return event.EventTime.Time
+	}
+
+	if !event.LastTimestamp.IsZero() {
+		return event.LastTimestamp.Time
+	}
+
+	return event.CreationTimestamp.Time
+}
+
+func eventGroupKey(record EventRecord) string {
+	return strings.Join(
+		[]string{
+			record.Namespace,
+			record.Type,
+			record.Reason,
+			record.Kind,
+			record.Name,
+			record.Message,
+		},
+		"\x00",
+	)
+}
+
+func sortEventRecords(records []EventRecord) {
+	sort.SliceStable(records, func(i, j int) bool {
+		if records[i].LastSeen.Equal(records[j].LastSeen) {
+			if records[i].Type != records[j].Type {
+				return records[i].Type < records[j].Type
+			}
+
+			if records[i].Kind != records[j].Kind {
+				return records[i].Kind < records[j].Kind
+			}
+
+			return records[i].Name < records[j].Name
+		}
+
+		return records[i].LastSeen.After(records[j].LastSeen)
+	})
+}

--- a/internal/kubernetes/events_test.go
+++ b/internal/kubernetes/events_test.go
@@ -1,0 +1,120 @@
+package kubernetes
+
+import (
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestEventRecordsGroupsRepeatedEvents(t *testing.T) {
+	t.Parallel()
+
+	first := time.Date(2026, 7, 21, 8, 0, 0, 0, time.UTC)
+	second := first.Add(2 * time.Minute)
+
+	events := []corev1.Event{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:         "test",
+				CreationTimestamp: metav1.NewTime(first),
+			},
+			Type:    "Warning",
+			Reason:  "BackOff",
+			Message: "Back-off restarting failed container",
+			Count:   2,
+			InvolvedObject: corev1.ObjectReference{
+				Kind: "Pod",
+				Name: "api-123",
+			},
+			LastTimestamp: metav1.NewTime(first),
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:         "test",
+				CreationTimestamp: metav1.NewTime(second),
+			},
+			Type:    "Warning",
+			Reason:  "BackOff",
+			Message: "Back-off restarting failed container",
+			Count:   3,
+			InvolvedObject: corev1.ObjectReference{
+				Kind: "Pod",
+				Name: "api-123",
+			},
+			LastTimestamp: metav1.NewTime(second),
+		},
+	}
+
+	records := EventRecords(events, true)
+
+	if len(records) != 1 {
+		t.Fatalf("expected one grouped event, got %#v", records)
+	}
+
+	if records[0].Count != 5 {
+		t.Fatalf("expected grouped count 5, got %d", records[0].Count)
+	}
+
+	if !records[0].LastSeen.Equal(second) {
+		t.Fatalf("expected last seen %v, got %v", second, records[0].LastSeen)
+	}
+}
+
+func TestEventRecordsWithoutGroupingPreservesItems(t *testing.T) {
+	t.Parallel()
+
+	events := []corev1.Event{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "test",
+			},
+			Type:   "Normal",
+			Reason: "Pulled",
+			InvolvedObject: corev1.ObjectReference{
+				Kind: "Pod",
+				Name: "api-123",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "test",
+			},
+			Type:   "Normal",
+			Reason: "Pulled",
+			InvolvedObject: corev1.ObjectReference{
+				Kind: "Pod",
+				Name: "api-123",
+			},
+		},
+	}
+
+	records := EventRecords(events, false)
+
+	if len(records) != 2 {
+		t.Fatalf("expected two ungrouped events, got %#v", records)
+	}
+}
+
+func TestEventRecordsUsesSeriesLastObservedTime(t *testing.T) {
+	t.Parallel()
+
+	observed := time.Date(2026, 7, 21, 9, 0, 0, 0, time.UTC)
+
+	event := corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			CreationTimestamp: metav1.NewTime(observed.Add(-time.Hour)),
+		},
+		Series: &corev1.EventSeries{
+			Count:            7,
+			LastObservedTime: metav1.NewMicroTime(observed),
+		},
+	}
+
+	records := EventRecords([]corev1.Event{event}, true)
+
+	if !records[0].LastSeen.Equal(observed) {
+		t.Fatalf("expected series timestamp %v, got %v", observed, records[0].LastSeen)
+	}
+}

--- a/internal/ui/event_detail.go
+++ b/internal/ui/event_detail.go
@@ -1,0 +1,98 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	kube "github.com/pierinho13/kubectl-peek/internal/kubernetes"
+)
+
+func RenderEventDetail(event kube.EventRecord) string {
+	var builder strings.Builder
+
+	builder.WriteString(titleStyle.Render("Event details"))
+	builder.WriteString("\n")
+	builder.WriteString(secretSeparatorStyle.Render(strings.Repeat("─", 60)))
+	builder.WriteString("\n\n")
+
+	renderEventDetailLine(&builder, "Type", event.Type)
+	renderEventDetailLine(&builder, "Reason", event.Reason)
+	renderEventDetailLine(&builder, "Object", event.Kind+"/"+event.Name)
+
+	if event.Namespace != "" {
+		renderEventDetailLine(&builder, "Namespace", event.Namespace)
+	}
+
+	renderEventDetailLine(
+		&builder,
+		"Occurrences",
+		fmt.Sprintf("%d", event.Count),
+	)
+
+	if event.EventObjects > 1 {
+		renderEventDetailLine(
+			&builder,
+			"Grouped Event objects",
+			fmt.Sprintf("%d", event.EventObjects),
+		)
+	}
+	renderEventDetailLine(&builder, "First seen", formatEventTimestamp(event.FirstSeen))
+	renderEventDetailLine(&builder, "Last seen", formatEventTimestamp(event.LastSeen))
+
+	if event.Source != "" {
+		renderEventDetailLine(&builder, "Source", event.Source)
+	}
+
+	builder.WriteString("\n")
+	builder.WriteString(secretMetadataLabelStyle.Render("Message:"))
+	builder.WriteString("\n")
+	builder.WriteString(event.Message)
+
+	return strings.TrimRight(builder.String(), "\n")
+}
+
+func renderEventDetailLine(
+	builder *strings.Builder,
+	label string,
+	value string,
+) {
+	builder.WriteString(secretMetadataLabelStyle.Render(label + ":"))
+	builder.WriteString(" ")
+	builder.WriteString(value)
+	builder.WriteString("\n")
+}
+
+func formatEventTimestamp(value time.Time) string {
+	if value.IsZero() {
+		return "unknown"
+	}
+
+	return fmt.Sprintf(
+		"%s (%s ago)",
+		value.Local().Format("2006-01-02 15:04:05 MST"),
+		formatEventAge(value),
+	)
+}
+
+func formatEventAge(value time.Time) string {
+	if value.IsZero() {
+		return "unknown"
+	}
+
+	duration := time.Since(value)
+	if duration < 0 {
+		duration = 0
+	}
+
+	switch {
+	case duration < time.Minute:
+		return fmt.Sprintf("%ds", int(duration.Seconds()))
+	case duration < time.Hour:
+		return fmt.Sprintf("%dm", int(duration.Minutes()))
+	case duration < 24*time.Hour:
+		return fmt.Sprintf("%dh", int(duration.Hours()))
+	default:
+		return fmt.Sprintf("%dd", int(duration.Hours()/24))
+	}
+}

--- a/internal/ui/event_kind_selector.go
+++ b/internal/ui/event_kind_selector.go
@@ -1,0 +1,452 @@
+package ui
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"unicode"
+
+	tea "charm.land/bubbletea/v2"
+
+	kube "github.com/pierinho13/kubectl-peek/internal/kubernetes"
+)
+
+type EventKindOption struct {
+	Kind        string
+	Resources   int
+	Events      int
+	Occurrences int64
+}
+
+type eventKindSelectorModel struct {
+	all      []EventKindOption
+	filtered []EventKindOption
+
+	filter    []rune
+	filtering bool
+
+	cursor   int
+	page     int
+	pageSize int
+
+	selected  string
+	cancelled bool
+
+	windowHeight int
+}
+
+func eventKindOptions(
+	events []kube.EventRecord,
+) []EventKindOption {
+	type aggregate struct {
+		resources   map[string]struct{}
+		events      int
+		occurrences int64
+	}
+
+	byKind := make(map[string]*aggregate)
+
+	for _, event := range events {
+		kind := event.Kind
+		if kind == "" {
+			kind = "<unknown>"
+		}
+
+		current, found := byKind[kind]
+		if !found {
+			current = &aggregate{
+				resources: make(map[string]struct{}),
+			}
+			byKind[kind] = current
+		}
+
+		resourceKey := event.Namespace + "\x00" + event.Name
+		current.resources[resourceKey] = struct{}{}
+		current.events++
+		current.occurrences += int64(event.Count)
+	}
+
+	options := make([]EventKindOption, 0, len(byKind))
+
+	for kind, aggregate := range byKind {
+		options = append(
+			options,
+			EventKindOption{
+				Kind:        kind,
+				Resources:   len(aggregate.resources),
+				Events:      aggregate.events,
+				Occurrences: aggregate.occurrences,
+			},
+		)
+	}
+
+	sort.Slice(options, func(i, j int) bool {
+		if options[i].Occurrences != options[j].Occurrences {
+			return options[i].Occurrences > options[j].Occurrences
+		}
+
+		return options[i].Kind < options[j].Kind
+	})
+
+	return options
+}
+
+func newEventKindSelectorModel(
+	events []kube.EventRecord,
+) eventKindSelectorModel {
+	options := eventKindOptions(events)
+
+	return eventKindSelectorModel{
+		all:      options,
+		filtered: options,
+		pageSize: defaultPageSize,
+	}
+}
+
+func (m eventKindSelectorModel) Init() tea.Cmd {
+	return nil
+}
+
+func (m eventKindSelectorModel) Update(
+	msg tea.Msg,
+) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.windowHeight = msg.Height
+		return m, nil
+
+	case tea.KeyPressMsg:
+		key := msg.String()
+
+		if m.filtering {
+			return m.updateFiltering(msg, key)
+		}
+
+		switch key {
+		case "ctrl+c", "esc", "q":
+			m.cancelled = true
+			return m, tea.Quit
+
+		case "/":
+			m.filtering = true
+			return m, nil
+
+		case "up", "k":
+			m.moveUp()
+			return m, nil
+
+		case "down", "j":
+			m.moveDown()
+			return m, nil
+
+		case "left":
+			m.previousPage()
+			return m, nil
+
+		case "right":
+			m.nextPage()
+			return m, nil
+
+		case "enter":
+			if len(m.filtered) == 0 {
+				return m, nil
+			}
+
+			m.selected = m.filtered[m.cursor].Kind
+			return m, tea.Quit
+		}
+	}
+
+	return m, nil
+}
+
+func (m eventKindSelectorModel) updateFiltering(
+	msg tea.KeyPressMsg,
+	key string,
+) (tea.Model, tea.Cmd) {
+	switch key {
+	case "ctrl+c":
+		m.cancelled = true
+		return m, tea.Quit
+
+	case "esc":
+		m.filtering = false
+		return m, nil
+
+	case "enter":
+		if len(m.filtered) == 0 {
+			return m, nil
+		}
+
+		m.selected = m.filtered[m.cursor].Kind
+		return m, tea.Quit
+
+	case "backspace":
+		if len(m.filter) > 0 {
+			m.filter = m.filter[:len(m.filter)-1]
+			m.applyFilter()
+		}
+		return m, nil
+
+	case "up":
+		m.moveUp()
+		return m, nil
+
+	case "down":
+		m.moveDown()
+		return m, nil
+	}
+
+	for _, character := range msg.Text {
+		if unicode.IsPrint(character) {
+			m.filter = append(m.filter, character)
+		}
+	}
+
+	m.applyFilter()
+	return m, nil
+}
+
+func (m *eventKindSelectorModel) applyFilter() {
+	query := strings.ToLower(
+		strings.TrimSpace(string(m.filter)),
+	)
+
+	m.filtered = nil
+
+	for _, option := range m.all {
+		if query == "" ||
+			strings.Contains(
+				strings.ToLower(option.Kind),
+				query,
+			) {
+			m.filtered = append(m.filtered, option)
+		}
+	}
+
+	m.cursor = 0
+	m.page = 0
+}
+
+func (m *eventKindSelectorModel) moveUp() {
+	if m.cursor > 0 {
+		m.cursor--
+	}
+
+	if !m.hasFilter() {
+		m.page = m.cursor / m.pageSize
+	}
+}
+
+func (m *eventKindSelectorModel) moveDown() {
+	if m.cursor < len(m.filtered)-1 {
+		m.cursor++
+	}
+
+	if !m.hasFilter() {
+		m.page = m.cursor / m.pageSize
+	}
+}
+
+func (m *eventKindSelectorModel) previousPage() {
+	if m.hasFilter() || m.page == 0 {
+		return
+	}
+
+	m.page--
+	m.cursor = m.page * m.pageSize
+}
+
+func (m *eventKindSelectorModel) nextPage() {
+	if m.hasFilter() || m.page >= m.totalPages()-1 {
+		return
+	}
+
+	m.page++
+	m.cursor = m.page * m.pageSize
+}
+
+func (m eventKindSelectorModel) hasFilter() bool {
+	return strings.TrimSpace(string(m.filter)) != ""
+}
+
+func (m eventKindSelectorModel) totalPages() int {
+	if len(m.filtered) == 0 {
+		return 1
+	}
+
+	return (len(m.filtered) + m.pageSize - 1) /
+		m.pageSize
+}
+
+func (m eventKindSelectorModel) visible() (
+	[]EventKindOption,
+	int,
+) {
+	if len(m.filtered) == 0 {
+		return nil, 0
+	}
+
+	if !m.hasFilter() {
+		start := m.page * m.pageSize
+		end := start + m.pageSize
+
+		if end > len(m.filtered) {
+			end = len(m.filtered)
+		}
+
+		return m.filtered[start:end], start
+	}
+
+	maxVisible := m.windowHeight - 8
+	if maxVisible < 5 {
+		maxVisible = 5
+	}
+	if maxVisible > len(m.filtered) {
+		maxVisible = len(m.filtered)
+	}
+
+	start := m.cursor - maxVisible/2
+	if start < 0 {
+		start = 0
+	}
+
+	maxStart := len(m.filtered) - maxVisible
+	if start > maxStart {
+		start = maxStart
+	}
+
+	return m.filtered[start : start+maxVisible], start
+}
+
+func (m eventKindSelectorModel) View() tea.View {
+	var builder strings.Builder
+
+	builder.WriteString(
+		titleStyle.Render("Select a resource kind"),
+	)
+	builder.WriteString("\n")
+
+	if m.filtering || m.hasFilter() {
+		builder.WriteString(
+			filterStyle.Render("/" + string(m.filter)),
+		)
+		builder.WriteString("\n")
+	}
+
+	builder.WriteString(descriptionStyle.Render(
+		"Use ↑/↓ to move, ←/→ to change page, / to filter, and Enter to select.",
+	))
+	builder.WriteString("\n\n")
+
+	builder.WriteString(descriptionStyle.Render(
+		fmt.Sprintf(
+			"  %-30s %10s %8s %12s",
+			"KIND",
+			"RESOURCES",
+			"EVENTS",
+			"OCCURRENCES",
+		),
+	))
+	builder.WriteString("\n")
+
+	visible, offset := m.visible()
+
+	if len(visible) == 0 {
+		builder.WriteString(
+			emptyStyle.Render("  No matching resource kinds"),
+		)
+		builder.WriteString("\n")
+	} else {
+		for index, option := range visible {
+			selected := offset+index == m.cursor
+			marker := "  "
+			style := normalStyle
+
+			if selected {
+				marker = "> "
+				style = selectedStyle
+			}
+
+			line := fmt.Sprintf(
+				"%-30s %10d %8d %12s",
+				option.Kind,
+				option.Resources,
+				option.Events,
+				formatEventCount(int32(option.Occurrences)),
+			)
+
+			builder.WriteString(style.Render(marker + line))
+			builder.WriteString("\n")
+		}
+	}
+
+	builder.WriteString("\n")
+	builder.WriteString(footerStyle.Render(m.footer()))
+
+	view := tea.NewView(builder.String())
+	view.AltScreen = true
+
+	return view
+}
+
+func (m eventKindSelectorModel) footer() string {
+	if m.hasFilter() {
+		if len(m.filtered) == 0 {
+			return "0 matching resource kinds"
+		}
+
+		return fmt.Sprintf(
+			"%d matching resource kinds · %d/%d selected",
+			len(m.filtered),
+			m.cursor+1,
+			len(m.filtered),
+		)
+	}
+
+	return fmt.Sprintf(
+		"Page %d/%d · %d resource kinds",
+		m.page+1,
+		m.totalPages(),
+		len(m.filtered),
+	)
+}
+
+func SelectEventKind(
+	events []kube.EventRecord,
+) (string, error) {
+	if len(events) == 0 {
+		return "", fmt.Errorf(
+			"no Kubernetes events found",
+		)
+	}
+
+	finalModel, err := tea.NewProgram(
+		newEventKindSelectorModel(events),
+	).Run()
+	if err != nil {
+		return "", fmt.Errorf(
+			"run event kind selector: %w",
+			err,
+		)
+	}
+
+	result, ok := finalModel.(eventKindSelectorModel)
+	if !ok {
+		return "", fmt.Errorf(
+			"unexpected event kind selector model",
+		)
+	}
+
+	if result.cancelled {
+		return "", fmt.Errorf("selection cancelled")
+	}
+
+	if result.selected == "" {
+		return "", fmt.Errorf(
+			"no resource kind selected",
+		)
+	}
+
+	return result.selected, nil
+}

--- a/internal/ui/event_kind_selector_test.go
+++ b/internal/ui/event_kind_selector_test.go
@@ -1,0 +1,59 @@
+package ui
+
+import (
+	"testing"
+
+	kube "github.com/pierinho13/kubectl-peek/internal/kubernetes"
+)
+
+func TestEventKindOptionsAggregatesResourcesAndOccurrences(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	options := eventKindOptions(
+		[]kube.EventRecord{
+			{
+				Namespace: "test",
+				Kind:      "Pod",
+				Name:      "api",
+				Count:     10,
+			},
+			{
+				Namespace: "test",
+				Kind:      "Pod",
+				Name:      "api",
+				Count:     20,
+			},
+			{
+				Namespace: "test",
+				Kind:      "Pod",
+				Name:      "worker",
+				Count:     5,
+			},
+			{
+				Namespace: "test",
+				Kind:      "Deployment",
+				Name:      "web",
+				Count:     2,
+			},
+		},
+	)
+
+	if len(options) != 2 {
+		t.Fatalf("expected two kinds, got %#v", options)
+	}
+
+	if options[0].Kind != "Pod" {
+		t.Fatalf("expected Pod first, got %#v", options)
+	}
+
+	if options[0].Resources != 2 ||
+		options[0].Events != 3 ||
+		options[0].Occurrences != 35 {
+		t.Fatalf(
+			"unexpected Pod aggregate: %#v",
+			options[0],
+		)
+	}
+}

--- a/internal/ui/event_resource_selector.go
+++ b/internal/ui/event_resource_selector.go
@@ -1,0 +1,482 @@
+package ui
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"unicode"
+
+	tea "charm.land/bubbletea/v2"
+
+	kube "github.com/pierinho13/kubectl-peek/internal/kubernetes"
+)
+
+type EventResourceSelection struct {
+	Namespace string
+	Name      string
+}
+
+type EventResourceOption struct {
+	Namespace   string
+	Name        string
+	Events      int
+	Occurrences int64
+}
+
+type eventResourceSelectorModel struct {
+	kind          string
+	allNamespaces bool
+
+	all      []EventResourceOption
+	filtered []EventResourceOption
+
+	filter    []rune
+	filtering bool
+
+	cursor   int
+	page     int
+	pageSize int
+
+	selected  *EventResourceSelection
+	cancelled bool
+
+	windowHeight int
+}
+
+func eventResourceOptions(
+	kind string,
+	events []kube.EventRecord,
+) []EventResourceOption {
+	optionsByKey := make(map[string]EventResourceOption)
+
+	for _, event := range events {
+		if event.Kind != kind {
+			continue
+		}
+
+		key := event.Namespace + "\x00" + event.Name
+		option := optionsByKey[key]
+
+		option.Namespace = event.Namespace
+		option.Name = event.Name
+		option.Events++
+		option.Occurrences += int64(event.Count)
+
+		optionsByKey[key] = option
+	}
+
+	options := make(
+		[]EventResourceOption,
+		0,
+		len(optionsByKey),
+	)
+
+	for _, option := range optionsByKey {
+		options = append(options, option)
+	}
+
+	sort.Slice(options, func(i, j int) bool {
+		if options[i].Occurrences != options[j].Occurrences {
+			return options[i].Occurrences >
+				options[j].Occurrences
+		}
+
+		if options[i].Namespace != options[j].Namespace {
+			return options[i].Namespace <
+				options[j].Namespace
+		}
+
+		return options[i].Name < options[j].Name
+	})
+
+	return options
+}
+
+func newEventResourceSelectorModel(
+	kind string,
+	events []kube.EventRecord,
+	allNamespaces bool,
+) eventResourceSelectorModel {
+	options := eventResourceOptions(kind, events)
+
+	return eventResourceSelectorModel{
+		kind:          kind,
+		allNamespaces: allNamespaces,
+		all:           options,
+		filtered:      options,
+		pageSize:      defaultPageSize,
+	}
+}
+
+func (m eventResourceSelectorModel) Init() tea.Cmd {
+	return nil
+}
+
+func (m eventResourceSelectorModel) Update(
+	msg tea.Msg,
+) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.windowHeight = msg.Height
+		return m, nil
+
+	case tea.KeyPressMsg:
+		key := msg.String()
+
+		if m.filtering {
+			return m.updateFiltering(msg, key)
+		}
+
+		switch key {
+		case "ctrl+c", "esc", "q":
+			m.cancelled = true
+			return m, tea.Quit
+
+		case "/":
+			m.filtering = true
+			return m, nil
+
+		case "up", "k":
+			m.moveUp()
+			return m, nil
+
+		case "down", "j":
+			m.moveDown()
+			return m, nil
+
+		case "left":
+			m.previousPage()
+			return m, nil
+
+		case "right":
+			m.nextPage()
+			return m, nil
+
+		case "enter":
+			return m.selectCurrent()
+		}
+	}
+
+	return m, nil
+}
+
+func (m eventResourceSelectorModel) updateFiltering(
+	msg tea.KeyPressMsg,
+	key string,
+) (tea.Model, tea.Cmd) {
+	switch key {
+	case "ctrl+c":
+		m.cancelled = true
+		return m, tea.Quit
+
+	case "esc":
+		m.filtering = false
+		return m, nil
+
+	case "enter":
+		return m.selectCurrent()
+
+	case "backspace":
+		if len(m.filter) > 0 {
+			m.filter = m.filter[:len(m.filter)-1]
+			m.applyFilter()
+		}
+		return m, nil
+
+	case "up":
+		m.moveUp()
+		return m, nil
+
+	case "down":
+		m.moveDown()
+		return m, nil
+	}
+
+	for _, character := range msg.Text {
+		if unicode.IsPrint(character) {
+			m.filter = append(m.filter, character)
+		}
+	}
+
+	m.applyFilter()
+	return m, nil
+}
+
+func (m eventResourceSelectorModel) selectCurrent() (
+	tea.Model,
+	tea.Cmd,
+) {
+	if len(m.filtered) == 0 {
+		return m, nil
+	}
+
+	option := m.filtered[m.cursor]
+	m.selected = &EventResourceSelection{
+		Namespace: option.Namespace,
+		Name:      option.Name,
+	}
+
+	return m, tea.Quit
+}
+
+func (m *eventResourceSelectorModel) applyFilter() {
+	query := strings.ToLower(
+		strings.TrimSpace(string(m.filter)),
+	)
+
+	m.filtered = nil
+
+	for _, option := range m.all {
+		searchable := strings.ToLower(
+			option.Namespace + " " + option.Name,
+		)
+
+		if query == "" ||
+			strings.Contains(searchable, query) {
+			m.filtered = append(m.filtered, option)
+		}
+	}
+
+	m.cursor = 0
+	m.page = 0
+}
+
+func (m *eventResourceSelectorModel) moveUp() {
+	if m.cursor > 0 {
+		m.cursor--
+	}
+
+	if !m.hasFilter() {
+		m.page = m.cursor / m.pageSize
+	}
+}
+
+func (m *eventResourceSelectorModel) moveDown() {
+	if m.cursor < len(m.filtered)-1 {
+		m.cursor++
+	}
+
+	if !m.hasFilter() {
+		m.page = m.cursor / m.pageSize
+	}
+}
+
+func (m *eventResourceSelectorModel) previousPage() {
+	if m.hasFilter() || m.page == 0 {
+		return
+	}
+
+	m.page--
+	m.cursor = m.page * m.pageSize
+}
+
+func (m *eventResourceSelectorModel) nextPage() {
+	if m.hasFilter() || m.page >= m.totalPages()-1 {
+		return
+	}
+
+	m.page++
+	m.cursor = m.page * m.pageSize
+}
+
+func (m eventResourceSelectorModel) hasFilter() bool {
+	return strings.TrimSpace(string(m.filter)) != ""
+}
+
+func (m eventResourceSelectorModel) totalPages() int {
+	if len(m.filtered) == 0 {
+		return 1
+	}
+
+	return (len(m.filtered) + m.pageSize - 1) /
+		m.pageSize
+}
+
+func (m eventResourceSelectorModel) visible() (
+	[]EventResourceOption,
+	int,
+) {
+	if len(m.filtered) == 0 {
+		return nil, 0
+	}
+
+	if !m.hasFilter() {
+		start := m.page * m.pageSize
+		end := start + m.pageSize
+
+		if end > len(m.filtered) {
+			end = len(m.filtered)
+		}
+
+		return m.filtered[start:end], start
+	}
+
+	maxVisible := m.windowHeight - 8
+	if maxVisible < 5 {
+		maxVisible = 5
+	}
+	if maxVisible > len(m.filtered) {
+		maxVisible = len(m.filtered)
+	}
+
+	start := m.cursor - maxVisible/2
+	if start < 0 {
+		start = 0
+	}
+
+	maxStart := len(m.filtered) - maxVisible
+	if start > maxStart {
+		start = maxStart
+	}
+
+	return m.filtered[start : start+maxVisible], start
+}
+
+func (m eventResourceSelectorModel) View() tea.View {
+	var builder strings.Builder
+
+	builder.WriteString(
+		titleStyle.Render(
+			fmt.Sprintf("Select a %s", m.kind),
+		),
+	)
+	builder.WriteString("\n")
+
+	if m.filtering || m.hasFilter() {
+		builder.WriteString(
+			filterStyle.Render("/" + string(m.filter)),
+		)
+		builder.WriteString("\n")
+	}
+
+	builder.WriteString(descriptionStyle.Render(
+		"Use ↑/↓ to move, ←/→ to change page, / to filter, and Enter to select.",
+	))
+	builder.WriteString("\n\n")
+
+	builder.WriteString(descriptionStyle.Render(
+		fmt.Sprintf(
+			"  %-58s %8s %12s",
+			"RESOURCE",
+			"EVENTS",
+			"OCCURRENCES",
+		),
+	))
+	builder.WriteString("\n")
+
+	visible, offset := m.visible()
+
+	if len(visible) == 0 {
+		builder.WriteString(
+			emptyStyle.Render("  No matching resources"),
+		)
+		builder.WriteString("\n")
+	} else {
+		for index, option := range visible {
+			selected := offset+index == m.cursor
+			marker := "  "
+			style := normalStyle
+
+			if selected {
+				marker = "> "
+				style = selectedStyle
+			}
+
+			resource := option.Name
+			if m.allNamespaces {
+				resource = option.Namespace + "/" + option.Name
+			}
+
+			resource = truncateEventColumn(resource, 58)
+
+			line := fmt.Sprintf(
+				"%-58s %8d %12s",
+				resource,
+				option.Events,
+				formatEventCount(int32(option.Occurrences)),
+			)
+
+			builder.WriteString(style.Render(marker + line))
+			builder.WriteString("\n")
+		}
+	}
+
+	builder.WriteString("\n")
+	builder.WriteString(footerStyle.Render(m.footer()))
+
+	view := tea.NewView(builder.String())
+	view.AltScreen = true
+
+	return view
+}
+
+func (m eventResourceSelectorModel) footer() string {
+	if m.hasFilter() {
+		if len(m.filtered) == 0 {
+			return "0 matching resources"
+		}
+
+		return fmt.Sprintf(
+			"%d matching resources · %d/%d selected",
+			len(m.filtered),
+			m.cursor+1,
+			len(m.filtered),
+		)
+	}
+
+	return fmt.Sprintf(
+		"Page %d/%d · %d resources",
+		m.page+1,
+		m.totalPages(),
+		len(m.filtered),
+	)
+}
+
+func SelectEventResource(
+	kind string,
+	events []kube.EventRecord,
+	allNamespaces bool,
+) (EventResourceSelection, error) {
+	options := eventResourceOptions(kind, events)
+	if len(options) == 0 {
+		return EventResourceSelection{}, fmt.Errorf(
+			"no resources found for kind %q",
+			kind,
+		)
+	}
+
+	finalModel, err := tea.NewProgram(
+		newEventResourceSelectorModel(
+			kind,
+			events,
+			allNamespaces,
+		),
+	).Run()
+	if err != nil {
+		return EventResourceSelection{}, fmt.Errorf(
+			"run event resource selector: %w",
+			err,
+		)
+	}
+
+	result, ok := finalModel.(eventResourceSelectorModel)
+	if !ok {
+		return EventResourceSelection{}, fmt.Errorf(
+			"unexpected event resource selector model",
+		)
+	}
+
+	if result.cancelled {
+		return EventResourceSelection{}, fmt.Errorf(
+			"selection cancelled",
+		)
+	}
+
+	if result.selected == nil {
+		return EventResourceSelection{}, fmt.Errorf(
+			"no resource selected",
+		)
+	}
+
+	return *result.selected, nil
+}

--- a/internal/ui/event_resource_selector_test.go
+++ b/internal/ui/event_resource_selector_test.go
@@ -1,0 +1,60 @@
+package ui
+
+import (
+	"testing"
+
+	kube "github.com/pierinho13/kubectl-peek/internal/kubernetes"
+)
+
+func TestEventResourceOptionsAggregatesByNamespaceAndName(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	options := eventResourceOptions(
+		"Pod",
+		[]kube.EventRecord{
+			{
+				Namespace: "first",
+				Kind:      "Pod",
+				Name:      "api",
+				Count:     10,
+			},
+			{
+				Namespace: "first",
+				Kind:      "Pod",
+				Name:      "api",
+				Count:     20,
+			},
+			{
+				Namespace: "second",
+				Kind:      "Pod",
+				Name:      "api",
+				Count:     5,
+			},
+			{
+				Namespace: "first",
+				Kind:      "Deployment",
+				Name:      "api",
+				Count:     100,
+			},
+		},
+	)
+
+	if len(options) != 2 {
+		t.Fatalf(
+			"expected two Pod resources, got %#v",
+			options,
+		)
+	}
+
+	if options[0].Namespace != "first" ||
+		options[0].Name != "api" ||
+		options[0].Events != 2 ||
+		options[0].Occurrences != 30 {
+		t.Fatalf(
+			"unexpected first resource aggregate: %#v",
+			options[0],
+		)
+	}
+}

--- a/internal/ui/event_selector.go
+++ b/internal/ui/event_selector.go
@@ -1,0 +1,570 @@
+package ui
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"unicode"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	kube "github.com/pierinho13/kubectl-peek/internal/kubernetes"
+)
+
+var (
+	eventNormalStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("#6A9955"))
+
+	eventWarningStyle = lipgloss.NewStyle().
+				Bold(true).
+				Foreground(lipgloss.Color("#D7A700"))
+
+	eventNonNormalStyle = lipgloss.NewStyle().
+				Bold(true).
+				Foreground(lipgloss.Color("#D75F5F"))
+)
+
+const (
+	eventLastWidth        = 8
+	eventTypeWidth        = 10
+	eventReasonWidth      = 22
+	eventOccurrencesWidth = 12
+	eventMinObjectWidth   = 24
+	eventMaxObjectWidth   = 58
+)
+
+type eventSelectorModel struct {
+	namespace string
+	grouped   bool
+
+	allEvents      []kube.EventRecord
+	filteredEvents []kube.EventRecord
+
+	filter    []rune
+	filtering bool
+
+	cursor   int
+	page     int
+	pageSize int
+
+	selected  *kube.EventRecord
+	cancelled bool
+
+	windowWidth  int
+	windowHeight int
+}
+
+func newEventSelectorModel(
+	namespace string,
+	events []kube.EventRecord,
+	grouped bool,
+) eventSelectorModel {
+	items := append([]kube.EventRecord(nil), events...)
+
+	sort.SliceStable(items, func(i, j int) bool {
+		return items[i].LastSeen.After(items[j].LastSeen)
+	})
+
+	return eventSelectorModel{
+		namespace:      namespace,
+		grouped:        grouped,
+		allEvents:      items,
+		filteredEvents: items,
+		pageSize:       defaultPageSize,
+	}
+}
+
+func (m eventSelectorModel) Init() tea.Cmd {
+	return nil
+}
+
+func (m eventSelectorModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.windowWidth = msg.Width
+		m.windowHeight = msg.Height
+		return m, nil
+
+	case tea.KeyPressMsg:
+		keyName := msg.String()
+
+		if m.filtering {
+			return m.updateFiltering(msg, keyName)
+		}
+
+		switch keyName {
+		case "ctrl+c", "esc", "q":
+			m.cancelled = true
+			return m, tea.Quit
+
+		case "/":
+			m.filtering = true
+			return m, nil
+
+		case "up", "k":
+			m.moveUp()
+			return m, nil
+
+		case "down", "j":
+			m.moveDown()
+			return m, nil
+
+		case "left":
+			m.previousPage()
+			return m, nil
+
+		case "right":
+			m.nextPage()
+			return m, nil
+
+		case "enter":
+			if len(m.filteredEvents) == 0 {
+				return m, nil
+			}
+
+			selected := m.filteredEvents[m.cursor]
+			m.selected = &selected
+			return m, tea.Quit
+		}
+	}
+
+	return m, nil
+}
+
+func (m eventSelectorModel) updateFiltering(
+	msg tea.KeyPressMsg,
+	keyName string,
+) (tea.Model, tea.Cmd) {
+	switch keyName {
+	case "ctrl+c":
+		m.cancelled = true
+		return m, tea.Quit
+
+	case "esc":
+		m.filtering = false
+		return m, nil
+
+	case "enter":
+		if len(m.filteredEvents) == 0 {
+			return m, nil
+		}
+
+		selected := m.filteredEvents[m.cursor]
+		m.selected = &selected
+		return m, tea.Quit
+
+	case "backspace":
+		if len(m.filter) > 0 {
+			m.filter = m.filter[:len(m.filter)-1]
+			m.applyFilter()
+		}
+		return m, nil
+
+	case "up":
+		m.moveUp()
+		return m, nil
+
+	case "down":
+		m.moveDown()
+		return m, nil
+	}
+
+	if msg.Text == "" {
+		return m, nil
+	}
+
+	for _, character := range msg.Text {
+		if unicode.IsPrint(character) {
+			m.filter = append(m.filter, character)
+		}
+	}
+
+	m.applyFilter()
+	return m, nil
+}
+
+func (m *eventSelectorModel) applyFilter() {
+	query := strings.ToLower(strings.TrimSpace(string(m.filter)))
+
+	if query == "" {
+		m.filteredEvents = m.allEvents
+	} else {
+		m.filteredEvents = make([]kube.EventRecord, 0)
+
+		for _, event := range m.allEvents {
+			searchable := strings.ToLower(strings.Join(
+				[]string{
+					event.Namespace,
+					event.Type,
+					event.Reason,
+					event.Kind,
+					event.Name,
+					event.Message,
+					event.Source,
+				},
+				" ",
+			))
+
+			if strings.Contains(searchable, query) {
+				m.filteredEvents = append(m.filteredEvents, event)
+			}
+		}
+	}
+
+	m.cursor = 0
+	m.page = 0
+}
+
+func (m *eventSelectorModel) moveUp() {
+	if len(m.filteredEvents) == 0 {
+		return
+	}
+
+	if m.cursor > 0 {
+		m.cursor--
+	}
+
+	if !m.hasFilter() {
+		m.page = m.cursor / m.pageSize
+	}
+}
+
+func (m *eventSelectorModel) moveDown() {
+	if len(m.filteredEvents) == 0 {
+		return
+	}
+
+	if m.cursor < len(m.filteredEvents)-1 {
+		m.cursor++
+	}
+
+	if !m.hasFilter() {
+		m.page = m.cursor / m.pageSize
+	}
+}
+
+func (m *eventSelectorModel) previousPage() {
+	if m.hasFilter() || m.page == 0 {
+		return
+	}
+
+	m.page--
+	m.cursor = m.page * m.pageSize
+}
+
+func (m *eventSelectorModel) nextPage() {
+	if m.hasFilter() || m.page >= m.totalPages()-1 {
+		return
+	}
+
+	m.page++
+	m.cursor = m.page * m.pageSize
+}
+
+func (m eventSelectorModel) hasFilter() bool {
+	return strings.TrimSpace(string(m.filter)) != ""
+}
+
+func (m eventSelectorModel) totalPages() int {
+	if len(m.filteredEvents) == 0 {
+		return 1
+	}
+
+	return (len(m.filteredEvents) + m.pageSize - 1) / m.pageSize
+}
+
+func (m eventSelectorModel) visibleEvents() ([]kube.EventRecord, int) {
+	if len(m.filteredEvents) == 0 {
+		return nil, 0
+	}
+
+	if !m.hasFilter() {
+		start := m.page * m.pageSize
+		end := start + m.pageSize
+		if end > len(m.filteredEvents) {
+			end = len(m.filteredEvents)
+		}
+
+		return m.filteredEvents[start:end], start
+	}
+
+	maxVisible := m.windowHeight - 8
+	if maxVisible < 5 {
+		maxVisible = 5
+	}
+	if maxVisible > len(m.filteredEvents) {
+		maxVisible = len(m.filteredEvents)
+	}
+
+	start := m.cursor - maxVisible/2
+	if start < 0 {
+		start = 0
+	}
+
+	maxStart := len(m.filteredEvents) - maxVisible
+	if start > maxStart {
+		start = maxStart
+	}
+
+	return m.filteredEvents[start : start+maxVisible], start
+}
+
+func (m eventSelectorModel) View() tea.View {
+	var builder strings.Builder
+
+	title := "Select a Kubernetes event"
+	if m.namespace != "" {
+		title = fmt.Sprintf("Select an event from namespace %q", m.namespace)
+	}
+
+	builder.WriteString(titleStyle.Render(title))
+	builder.WriteString("\n")
+
+	mode := "raw"
+	if m.grouped {
+		mode = "grouped"
+	}
+
+	builder.WriteString(descriptionStyle.Render(
+		fmt.Sprintf("%d %s events", len(m.filteredEvents), mode),
+	))
+	builder.WriteString("\n")
+
+	if m.filtering || m.hasFilter() {
+		builder.WriteString(filterStyle.Render("/" + string(m.filter)))
+		builder.WriteString("\n")
+	}
+
+	builder.WriteString(descriptionStyle.Render(
+		"Use ↑/↓ to move, ←/→ to change page, / to filter, and Enter for details.",
+	))
+	builder.WriteString("\n\n")
+
+	objectWidth := eventObjectColumnWidth(m.windowWidth)
+
+	builder.WriteString(descriptionStyle.Render(
+		formatEventColumns(
+			"LAST",
+			"TYPE",
+			"REASON",
+			"OBJECT",
+			"OCCURRENCES",
+			objectWidth,
+		),
+	))
+	builder.WriteString("\n")
+
+	visible, offset := m.visibleEvents()
+	if len(visible) == 0 {
+		builder.WriteString(emptyStyle.Render("  No matching events"))
+		builder.WriteString("\n")
+	} else {
+		for index, event := range visible {
+			absoluteIndex := offset + index
+			selected := absoluteIndex == m.cursor
+
+			builder.WriteString(
+				renderEventLine(event, selected, objectWidth),
+			)
+			builder.WriteString("\n")
+
+			if selected && event.Message != "" {
+				messageWidth := m.windowWidth - 4
+				if messageWidth < 40 {
+					messageWidth = 40
+				}
+
+				builder.WriteString(descriptionStyle.Render(
+					"    " + compactEventMessage(
+						event.Message,
+						messageWidth,
+					),
+				))
+				builder.WriteString("\n")
+			}
+		}
+	}
+
+	builder.WriteString("\n")
+	builder.WriteString(footerStyle.Render(m.footer()))
+
+	view := tea.NewView(builder.String())
+	view.AltScreen = true
+
+	return view
+}
+
+func (m eventSelectorModel) footer() string {
+	if m.hasFilter() {
+		if len(m.filteredEvents) == 0 {
+			return "0 matching events"
+		}
+
+		return fmt.Sprintf(
+			"%d matching events · %d/%d selected",
+			len(m.filteredEvents),
+			m.cursor+1,
+			len(m.filteredEvents),
+		)
+	}
+
+	return fmt.Sprintf(
+		"Page %d/%d · %d events",
+		m.page+1,
+		m.totalPages(),
+		len(m.filteredEvents),
+	)
+}
+
+func renderEventLine(
+	event kube.EventRecord,
+	selected bool,
+	objectWidth int,
+) string {
+	marker := "  "
+	if selected {
+		marker = "> "
+	}
+
+	lastSeen := formatEventAge(event.LastSeen)
+	object := event.Kind + "/" + event.Name
+
+	line := formatEventColumns(
+		lastSeen,
+		event.Type,
+		event.Reason,
+		object,
+		formatEventCount(event.Count),
+		objectWidth,
+	)
+
+	if selected {
+		return selectedStyle.Render(marker + line)
+	}
+
+	switch event.Type {
+	case "Normal":
+		return marker + eventNormalStyle.Render(line)
+	case "Warning":
+		return marker + eventWarningStyle.Render(line)
+	default:
+		return marker + eventNonNormalStyle.Render(line)
+	}
+}
+
+func formatEventCount(count int32) string {
+	switch {
+	case count >= 1_000_000:
+		return fmt.Sprintf("%.1fM", float64(count)/1_000_000)
+	case count >= 1_000:
+		return fmt.Sprintf("%.1fk", float64(count)/1_000)
+	default:
+		return fmt.Sprintf("%d", count)
+	}
+}
+
+func formatEventColumns(
+	lastSeen string,
+	eventType string,
+	reason string,
+	object string,
+	occurrences string,
+	objectWidth int,
+) string {
+	return fmt.Sprintf(
+		"%-*s %-*s %-*s %-*s %*s",
+		eventLastWidth,
+		truncateEventColumn(lastSeen, eventLastWidth),
+		eventTypeWidth,
+		truncateEventColumn(eventType, eventTypeWidth),
+		eventReasonWidth,
+		truncateEventColumn(reason, eventReasonWidth),
+		objectWidth,
+		truncateEventColumn(object, objectWidth),
+		eventOccurrencesWidth,
+		truncateEventColumn(occurrences, eventOccurrencesWidth),
+	)
+}
+
+func eventObjectColumnWidth(windowWidth int) int {
+	const fixedWidth = 2 +
+		eventLastWidth + 1 +
+		eventTypeWidth + 1 +
+		eventReasonWidth + 1 +
+		1 + eventOccurrencesWidth
+
+	width := windowWidth - fixedWidth
+
+	if width < eventMinObjectWidth {
+		return eventMinObjectWidth
+	}
+
+	if width > eventMaxObjectWidth {
+		return eventMaxObjectWidth
+	}
+
+	return width
+}
+
+func truncateEventColumn(value string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+
+	runes := []rune(value)
+	if len(runes) <= width {
+		return value
+	}
+
+	if width == 1 {
+		return "…"
+	}
+
+	return string(runes[:width-1]) + "…"
+}
+
+func compactEventMessage(message string, limit int) string {
+	message = strings.Join(strings.Fields(message), " ")
+	if len(message) <= limit {
+		return message
+	}
+
+	if limit < 2 {
+		return message[:limit]
+	}
+
+	return message[:limit-1] + "…"
+}
+
+func SelectEvent(
+	namespace string,
+	events []kube.EventRecord,
+	grouped bool,
+) (kube.EventRecord, error) {
+	if len(events) == 0 {
+		return kube.EventRecord{}, fmt.Errorf("no Kubernetes events found")
+	}
+
+	finalModel, err := tea.NewProgram(
+		newEventSelectorModel(namespace, events, grouped),
+	).Run()
+	if err != nil {
+		return kube.EventRecord{}, fmt.Errorf("run event selector: %w", err)
+	}
+
+	result, ok := finalModel.(eventSelectorModel)
+	if !ok {
+		return kube.EventRecord{}, fmt.Errorf("unexpected event selector model")
+	}
+
+	if result.cancelled {
+		return kube.EventRecord{}, fmt.Errorf("selection cancelled")
+	}
+
+	if result.selected == nil {
+		return kube.EventRecord{}, fmt.Errorf("no event selected")
+	}
+
+	return *result.selected, nil
+}

--- a/internal/ui/event_selector_test.go
+++ b/internal/ui/event_selector_test.go
@@ -1,0 +1,126 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	kube "github.com/pierinho13/kubectl-peek/internal/kubernetes"
+)
+
+func TestEventSelectorFiltersAcrossEventFields(t *testing.T) {
+	t.Parallel()
+
+	model := newEventSelectorModel(
+		"test",
+		[]kube.EventRecord{
+			{
+				Type:    "Warning",
+				Reason:  "BackOff",
+				Kind:    "Pod",
+				Name:    "api-123",
+				Message: "Back-off restarting container",
+			},
+			{
+				Type:   "Normal",
+				Reason: "Pulled",
+				Kind:   "Pod",
+				Name:   "worker-123",
+			},
+		},
+		true,
+	)
+
+	model.filter = []rune("backoff")
+	model.applyFilter()
+
+	if len(model.filteredEvents) != 1 {
+		t.Fatalf("expected one matching event, got %#v", model.filteredEvents)
+	}
+
+	if model.filteredEvents[0].Name != "api-123" {
+		t.Fatalf("expected api-123, got %q", model.filteredEvents[0].Name)
+	}
+}
+
+func TestEventSelectorSortsNewestFirst(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	model := newEventSelectorModel(
+		"test",
+		[]kube.EventRecord{
+			{Name: "older", LastSeen: now.Add(-time.Minute)},
+			{Name: "newer", LastSeen: now},
+		},
+		true,
+	)
+
+	if model.allEvents[0].Name != "newer" {
+		t.Fatalf("expected newest event first, got %q", model.allEvents[0].Name)
+	}
+}
+
+func TestFormatEventCount(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		count int32
+		want  string
+	}{
+		{count: 42, want: "42"},
+		{count: 1_234, want: "1.2k"},
+		{count: 111_671, want: "111.7k"},
+		{count: 1_250_000, want: "1.2M"},
+	}
+
+	for _, test := range tests {
+		if got := formatEventCount(test.count); got != test.want {
+			t.Errorf("formatEventCount(%d) = %q, want %q", test.count, got, test.want)
+		}
+	}
+}
+
+func TestFormatEventColumnsKeepsOccurrencesAligned(t *testing.T) {
+	t.Parallel()
+
+	line := formatEventColumns(
+		"1m",
+		"Warning",
+		"AmbiguousSelector",
+		"HorizontalPodAutoscaler/iam-infinispan-with-a-very-long-name",
+		"111.9k",
+		36,
+	)
+
+	if !strings.HasSuffix(line, "      111.9k") {
+		t.Fatalf("occurrences column is not right-aligned: %q", line)
+	}
+
+	if strings.Contains(
+		line,
+		"iam-infinispan-with-a-very-long-name",
+	) {
+		t.Fatalf("expected long object name to be truncated: %q", line)
+	}
+}
+
+func TestEventObjectColumnWidthUsesTerminalWidth(t *testing.T) {
+	t.Parallel()
+
+	if got := eventObjectColumnWidth(80); got != eventMinObjectWidth {
+		t.Fatalf(
+			"eventObjectColumnWidth(80) = %d, want %d",
+			got,
+			eventMinObjectWidth,
+		)
+	}
+
+	if got := eventObjectColumnWidth(200); got != eventMaxObjectWidth {
+		t.Fatalf(
+			"eventObjectColumnWidth(200) = %d, want %d",
+			got,
+			eventMaxObjectWidth,
+		)
+	}
+}


### PR DESCRIPTION
## Summary

This PR adds an interactive `events` command to `kubectl-peek` for browsing Kubernetes Events in a clearer and more useful way than a flat `kubectl get events` output.

Events are ordered by their latest occurrence, grouped by default, filterable, and can be explored through a drill-down flow by resource kind and resource.

## Usage

```bash
kubectl-peek events
kubectl-peek events --warnings
kubectl-peek events --non-normal
kubectl-peek events --no-group
kubectl-peek events --browse
kubectl-peek events --browse-by-kind
kubectl-peek events -A --browse
kubectl-peek events backoff --browse
```

Aliases:

```bash
kubectl-peek event
kubectl-peek ev
```

## What changed

- Added `kubectl-peek events [pattern]`
- Added `event` and `ev` aliases
- Added sorting by latest event occurrence
- Added grouping of repeated events by default
- Added `--no-group` to display raw Event objects
- Added `--warnings`
- Added `--non-normal`
- Added `--namespace/-n`
- Added `--all-namespaces/-A`
- Added interactive filtering with `/`
- Added pagination and keyboard navigation
- Added type-specific colors and warning highlighting
- Added a details view on Enter
- Renamed `COUNT` to `OCCURRENCES` to avoid confusion with container restarts
- Added compact occurrence formatting such as `1.2k` and `165.9k`
- Added exact occurrence counts in the details view
- Added the number of grouped Event objects when applicable
- Added terminal-width-aware table alignment and truncation
- Added `--browse` and `--browse-by-kind`

## Browse flow

When browse mode is enabled, events are explored through:

```text
Kind → Resource → Events → Detail
```

The kind selector shows:

```text
KIND                         RESOURCES   EVENTS   OCCURRENCES
Pod                                  8       14        427.3k
HorizontalPodAutoscaler              3        5        444.8k
StatefulSet                          1        1           533
```

After selecting a kind, the resource selector shows the matching resources and their aggregated event counts. Selecting a resource opens only the events related to it.

Existing filters are applied before building the browse hierarchy, so this works naturally with:

```bash
kubectl-peek events --warnings --browse
kubectl-peek events --non-normal --browse
kubectl-peek events backoff --browse
```

## Event grouping

Grouped events use the following identity:

```text
namespace + type + reason + kind + name + message
```

For grouped records, `OCCURRENCES` is the combined occurrence count reported by Kubernetes across matching Event objects.

This value is intentionally different from container restart count. For example, one container restart may produce multiple `BackOff` event occurrences.

