### PR TITLE
feat: Improve Secret inspection privacy and usage messaging

### DIFF
--- a/cmd/secret.go
+++ b/cmd/secret.go
@@ -21,6 +21,8 @@ const usageRulesEnvVar = "KUBECTL_PEEK_RULE_FILE"
 var (
 	secretNamespace      string
 	secretUsageRulesFile string
+	secretShowUsage      bool
+	secretShowValues     bool
 )
 
 var secretCmd = &cobra.Command{
@@ -58,6 +60,20 @@ func init() {
 		os.Getenv(usageRulesEnvVar),
 		"Path to a YAML file containing custom Secret usage rules; defaults to $KUBECTL_PEEK_RULE_FILE",
 	)
+
+	secretCmd.Flags().BoolVar(
+		&secretShowUsage,
+		"show-usage",
+		false,
+		"Discover and display resources that use, produce, or reference the Secret",
+	)
+
+	secretCmd.Flags().BoolVar(
+		&secretShowValues,
+		"show-values",
+		true,
+		"Display decoded Secret values; use --show-values=false to redact them",
+	)
 }
 
 func runSecret(
@@ -74,14 +90,16 @@ func runSecret(
 		return err
 	}
 
-	usageRules, err := config.LoadUsageRules(
-		secretUsageRulesFile,
-	)
-	if err != nil {
-		return err
-	}
+	if secretShowUsage {
+		usageRules, err := config.LoadUsageRules(
+			secretUsageRulesFile,
+		)
+		if err != nil {
+			return err
+		}
 
-	client.UsageRules = usageRules
+		client.UsageRules = usageRules
+	}
 
 	secrets, err := client.Clientset.
 		CoreV1().
@@ -161,23 +179,32 @@ func runSecret(
 		return ui.RenderEmptySecretError(secret.Name)
 	}
 
-	result, err := kubernetes.FindSecretUsagesDetailed(
-		ctx,
-		client,
-		client.Namespace,
-		secret.Name,
-	)
-	if err != nil {
-		return fmt.Errorf(
-			"find secret usages: %w",
-			err,
+	var result kubernetes.SecretUsageResult
+
+	if secretShowUsage {
+		result, err = kubernetes.FindSecretUsagesDetailed(
+			ctx,
+			client,
+			client.Namespace,
+			secret.Name,
 		)
+		if err != nil {
+			return fmt.Errorf(
+				"find secret usages: %w",
+				err,
+			)
+		}
 	}
 
 	fmt.Fprintln(out)
 	fmt.Fprintln(
 		out,
-		ui.RenderSecret(secret, result),
+		ui.RenderSecret(
+			secret,
+			result,
+			secretShowUsage,
+			secretShowValues,
+		),
 	)
 
 	return nil

--- a/internal/ui/secret_output.go
+++ b/internal/ui/secret_output.go
@@ -30,6 +30,8 @@ var (
 func RenderSecret(
 	secret *corev1.Secret,
 	result kube.SecretUsageResult,
+	showUsage bool,
+	showValues bool,
 ) string {
 	var builder strings.Builder
 
@@ -37,8 +39,10 @@ func RenderSecret(
 	renderMetadataLine(&builder, "Namespace", secret.Namespace)
 	renderMetadataLine(&builder, "Type", string(secret.Type))
 
-	renderSecretUsages(&builder, result.Usages)
-	renderSecretWarnings(&builder, result.Warnings)
+	if showUsage {
+		renderSecretUsages(&builder, result.Usages)
+		renderSecretWarnings(&builder, result.Warnings)
+	}
 
 	keys := make([]string, 0, len(secret.Data))
 
@@ -49,9 +53,9 @@ func RenderSecret(
 	sort.Strings(keys)
 
 	for _, key := range keys {
-		value := strings.TrimSuffix(
-			string(secret.Data[key]),
-			"\n",
+		value := renderSecretValue(
+			secret.Data[key],
+			showValues,
 		)
 
 		builder.WriteString("\n")
@@ -68,6 +72,23 @@ func RenderSecret(
 	}
 
 	return strings.TrimRight(builder.String(), "\n")
+}
+
+func renderSecretValue(
+	value []byte,
+	showValue bool,
+) string {
+	if !showValue {
+		return fmt.Sprintf(
+			"<redacted: %d bytes>",
+			len(value),
+		)
+	}
+
+	return strings.TrimSuffix(
+		string(value),
+		"\n",
+	)
 }
 
 func renderMetadataLine(
@@ -100,7 +121,18 @@ func renderSecretUsages(
 	builder.WriteString("\n")
 
 	if len(usages) == 0 {
-		builder.WriteString("  none")
+		builder.WriteString(
+			"  No references were found among the supported " +
+				"built-in resources and configured usage rules.",
+		)
+		builder.WriteString("\n")
+		builder.WriteString(
+			descriptionStyle.Render(
+				"  This does not guarantee that the Secret is unused; " +
+					"unsupported resources, external systems, or " +
+					"unconfigured custom resources may still reference it.",
+			),
+		)
 		builder.WriteString("\n")
 
 		return

--- a/internal/ui/secret_output_test.go
+++ b/internal/ui/secret_output_test.go
@@ -57,7 +57,7 @@ func TestRenderSecretIncludesUsagesAndWarnings(t *testing.T) {
 		},
 	}
 
-	output := RenderSecret(secret, result)
+	output := RenderSecret(secret, result, true, true)
 
 	expectedParts := []string{
 		"Secret:",
@@ -81,6 +81,68 @@ func TestRenderSecretIncludesUsagesAndWarnings(t *testing.T) {
 				output,
 			)
 		}
+	}
+}
+
+func TestRenderSecretHidesUsages(t *testing.T) {
+	t.Parallel()
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "database-credentials",
+			Namespace: "test",
+		},
+		Data: map[string][]byte{
+			"username": []byte("admin"),
+		},
+	}
+
+	result := kube.SecretUsageResult{
+		Usages: []kube.SecretUsage{
+			{
+				Kind: "Deployment",
+				Name: "backend",
+			},
+		},
+	}
+
+	output := RenderSecret(secret, result, false, true)
+
+	if strings.Contains(output, "Used by:") {
+		t.Fatalf("expected usages to be hidden\n\n%s", output)
+	}
+
+	if !strings.Contains(output, "admin") {
+		t.Fatalf("expected Secret value to remain visible\n\n%s", output)
+	}
+}
+
+func TestRenderSecretRedactsValuesWithByteCount(t *testing.T) {
+	t.Parallel()
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "database-credentials",
+			Namespace: "test",
+		},
+		Data: map[string][]byte{
+			"username": []byte("admin"),
+		},
+	}
+
+	output := RenderSecret(
+		secret,
+		kube.SecretUsageResult{},
+		false,
+		false,
+	)
+
+	if strings.Contains(output, "admin") {
+		t.Fatalf("expected Secret value to be redacted\n\n%s", output)
+	}
+
+	if !strings.Contains(output, "<redacted: 5 bytes>") {
+		t.Fatalf("expected redacted byte count\n\n%s", output)
 	}
 }
 

--- a/vhs/kubectl-peek-demo-updated.tape
+++ b/vhs/kubectl-peek-demo-updated.tape
@@ -11,18 +11,25 @@ Set Theme "Dracula"
 Type "kubectl-peek secret"
 Enter
 Sleep 500ms
-Right
+Down
+Down
+Down
+Down
+Down
+Down
 Sleep 500ms
-Right
-Sleep 500ms
+Enter
 
+Type "kubectl-peek secret -n monitoring --show-usage"
+Enter
+Sleep 500ms
 Type "/"
 Sleep 500ms
-Type "apm-server-apm-config"
+Type "grafana"
 Enter
 Sleep 100ms
 
-ScrollUp@250ms 40
+ScrollUp@250ms 100
 Sleep 1s
 
 # Exit kubectl-peek
@@ -30,13 +37,18 @@ Ctrl+C
 Sleep 1s
 
 # Show the custom rule file
-Ctrl+L
-Sleep 500ms
-Type "cat $HOME/.config/kubectl-peek/rules.yaml"
+Hide
+Type "unset KUBECTL_PEEK_RULE_FILE"
 Enter
-Sleep 2s
-
-ScrollUp@250ms 30
+Show
+Type "clear"
+Enter
+Sleep 500ms
+Type "more $HOME/.config/kubectl-peek/rules.yaml"
+Enter
+Enter
+Enter
+Type q 
 Sleep 2s
 
 # Configure the rule file through the environment variable
@@ -47,15 +59,13 @@ Sleep 1s
 # Second run: built-in and custom rule discovery
 Type "clear"
 Enter
-Type "kubectl-peek secret -n airflow"
+Type "kubectl-peek secret -n monitoring --show-usage"
 Enter
-Right
-Right
 
 Type "/"
-Type "airflow-metadata-db"
+Type "grafana"
 Enter
 Sleep 100ms
 
-ScrollUp@250ms 35
+ScrollUp@250ms 100
 Sleep 1s


### PR DESCRIPTION
## Summary

This PR improves the `kubectl-peek secret` workflow by making Secret inspection safer and more explicit.

By default, the command now shows Secret values without performing usage discovery. Relationship discovery is only executed when explicitly requested.

## Changes

### Usage discovery is now opt-in

`kubectl-peek secret` no longer searches for or displays related resources by default.

Use:

```bash
kubectl-peek secret --show-usage
```

to discover and display resources that use, produce, or reference the selected Secret.

This also avoids unnecessary API calls and permission warnings when relationship discovery is not needed.

### Secret values can be redacted

Secret values remain visible by default for backward compatibility.

Use:

```bash
kubectl-peek secret --show-values=false
```

to hide decoded values.

Redacted values keep the key name and display the original byte length:

```text
password:
────────────────────────────────────────────────────────────
<redacted: 24 bytes>
```

Both options can be combined:

```bash
kubectl-peek secret --show-usage --show-values=false
```

### Clearer message when no relationships are found

When usage discovery is enabled but no supported references are detected, the output now explains that the result is not a guarantee that the Secret is unused.

Example:

```text
Used by:
  No references were found among the supported built-in resources and configured usage rules.
  This does not guarantee that the Secret is unused; unsupported resources, external systems, or unconfigured custom resources may still reference it.
```

## Resulting behavior

```bash
kubectl-peek secret
```

- Displays decoded Secret values.
- Does not perform usage discovery.
- Does not display the `Used by` section.

```bash
kubectl-peek secret --show-usage
```

- Displays decoded Secret values.
- Discovers and displays supported relationships.

```bash
kubectl-peek secret --show-values=false
```

- Hides decoded values.
- Displays the byte length for each Secret entry.

```bash
kubectl-peek secret --show-usage --show-values=false
```

- Displays relationships.
- Keeps Secret values redacted.

