### PR TITLE
feat(namespace): switch namespaces inside the active isolated shell

### DIFF
--- a/cmd/namespace.go
+++ b/cmd/namespace.go
@@ -52,11 +52,8 @@ func runNamespace(
 	pattern string,
 	openShell bool,
 ) error {
-	if openShell {
-		if err := kubernetes.EnsureNoActiveNamespaceShell(); err != nil {
-			return err
-		}
-	}
+	activeShell := openShell &&
+		kubernetes.IsNamespaceShellActive()
 
 	client, err := kubernetes.NewClient(
 		kubeconfig,
@@ -107,6 +104,15 @@ func runNamespace(
 	}
 
 	if openShell {
+		if activeShell {
+			return kubernetes.SwitchNamespaceShell(
+				kubeconfig,
+				contextName,
+				selectedNamespace,
+				out,
+			)
+		}
+
 		return kubernetes.RunNamespaceShell(
 			kubeconfig,
 			contextName,

--- a/readme.md
+++ b/readme.md
@@ -90,6 +90,14 @@ A namespace-first isolated shell is also available:
 kubectl peek namespace --shell
 ```
 
+When already inside an active isolated shell, run the same command to switch only the namespace in place. The current context is preserved and no additional shell is created:
+
+```text
+[k8s:staging ns:ci] user@host %
+kubectl peek namespace --shell
+[k8s:staging ns:devbox-sre-3] user@host %
+```
+
 ![kubectl-peek namespace shell](https://github.com/user-attachments/assets/fae7e6dd-1a36-491b-a4fe-0cbe5eaed4ee)
 
 [Full shell and namespace documentation](docs/shells-and-namespaces.md)


### PR DESCRIPTION
## Summary

This PR extends the generation-based isolated shell workflow to `kubectl peek namespace --shell`.

When the command is executed from inside an active `kubectl-peek` shell, it now:

- opens the namespace selector;
- keeps the current Kubernetes context;
- creates and validates a new temporary session generation;
- atomically activates the selected namespace;
- refreshes the Bash or Zsh prompt;
- continues in the same isolated shell without nesting another shell.

## Why

`kubectl peek shell` already supports changing context and namespace inside the active isolated shell, but `kubectl peek namespace --shell` still rejected the operation with:

```text
an isolated kubectl-peek shell is already active; run exit before opening another one
```

This made both shell entry points behave differently.

## Behavior

Open an isolated shell:

```bash
kubectl peek shell --context staging --namespace ci
```

```text
[k8s:staging ns:ci] user@host %
```

Switch only the namespace from inside that shell:

```bash
kubectl peek namespace --shell
```

```text
[k8s:staging ns:devbox-sre-3] user@host %
```

The context remains unchanged, no additional shell is created, and a single `exit` still returns to the original parent shell.

## Implementation

`runNamespace` now detects whether `--shell` is being used inside an active isolated shell.

- Active isolated shell: calls `SwitchNamespaceShell`.
- No active isolated shell: calls `RunNamespaceShell`.
- Without `--shell`: preserves the existing persistent namespace behavior.

The change reuses the existing session generations, atomic activation, prompt refresh and cleanup logic.

## Testing

- [x] `gofmt -w cmd/namespace.go`
- [x] `go test -race ./...`
- [x] `go vet ./...`
- [x] `kubectl peek namespace --shell` opens a new isolated shell outside an active session
- [x] `kubectl peek namespace --shell` switches namespace in place inside an active session
- [x] The Kubernetes context remains unchanged
- [x] The prompt shows the selected namespace
- [x] `kubectl config view --minify` reports the selected namespace
- [x] A single `exit` returns to the original shell
